### PR TITLE
Avoiding inline fully qualified classes

### DIFF
--- a/generators/controller/templates/controller.php
+++ b/generators/controller/templates/controller.php
@@ -1,6 +1,7 @@
 <?php
 
 use yii\helpers\Inflector;
+use yii\helpers\StringHelper;
 
 /**
  * This is the template for generating a controller class file.
@@ -16,7 +17,9 @@ echo "<?php\n";
 namespace <?= $generator->ns ?>;
 <?php endif; ?>
 
-class <?= $generator->getControllerClass() ?> extends <?= '\\' . trim($generator->baseClass, '\\') . "\n" ?>
+use <?= $generator->baseClass ?>;
+
+class <?= $generator->getControllerClass() ?> extends <?= StringHelper::basename($generator->baseClass) . "\n" ?>
 {
 <?php foreach($generator->getActionIDs() as $action): ?>
 	public function action<?= Inflector::id2camel($action) ?>()

--- a/generators/model/templates/model.php
+++ b/generators/model/templates/model.php
@@ -1,4 +1,7 @@
 <?php
+
+use yii\helpers\StringHelper;
+
 /**
  * This is the template for generating the model class of a specified table.
  *
@@ -17,6 +20,11 @@ echo "<?php\n";
 
 namespace <?= $generator->ns ?>;
 
+use <?= $generator->baseClass ?>;
+<?php if (!empty($relations)): ?>
+use yii\db\ActiveRelation;
+<?php endif; ?>
+
 /**
  * This is the model class for table "<?= $tableName ?>".
  *
@@ -30,7 +38,7 @@ namespace <?= $generator->ns ?>;
 <?php endforeach; ?>
 <?php endif; ?>
  */
-class <?= $className ?> extends <?= '\\' . ltrim($generator->baseClass, '\\') . "\n" ?>
+class <?= $className ?> extends <?= StringHelper::basename($generator->baseClass) . "\n" ?>
 {
 	/**
 	 * @inheritdoc
@@ -62,7 +70,7 @@ class <?= $className ?> extends <?= '\\' . ltrim($generator->baseClass, '\\') . 
 <?php foreach ($relations as $name => $relation): ?>
 
 	/**
-	 * @return \yii\db\ActiveRelation
+	 * @return ActiveRelation
 	 */
 	public function get<?= $name ?>()
 	{

--- a/generators/module/templates/module.php
+++ b/generators/module/templates/module.php
@@ -15,8 +15,9 @@ echo "<?php\n";
 
 namespace <?= $ns ?>;
 
+use yii\base\Module
 
-class <?= $className ?> extends \yii\base\Module
+class <?= $className ?> extends Module
 {
 	public $controllerNamespace = '<?= $generator->getControllerNamespace() ?>';
 


### PR DESCRIPTION
There are inline fully qualified classes around inheritances or doc-comments in Gii generated codes.
I suggest to use `use` statement in all cases instead.
