### PR TITLE
Fixes 1897: gii diff - line number gets selected

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -148,6 +148,10 @@ body {
 	font-weight: normal;
 	color: #999;
 	width: 5px;
+
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	user-select: none;
 }
 
 .Differences td {


### PR DESCRIPTION
Currently in gii-diff the line numbers get selected (Issue: #1897 - https://github.com/yiisoft/yii2/issues/1897).

The diff gets created by an external library "Diff_Renderer_Html_Inline".
Therefor a modification in the generated html code will result in a lot of work.

i've chosen the github approach and added the user-select css property to the "line-number" columns.
here is the browser support for this property: http://caniuse.com/user-select-none
