### PR TITLE
fix if translation enabled on Model to add a \ for Yii

### DIFF
--- a/Generator.php
+++ b/Generator.php
@@ -500,7 +500,7 @@ abstract class Generator extends Model
             } else {
                 $ph = '';
             }
-            $str = "Yii::t('" . $this->messageCategory . "', '" . $string . "'" . $ph . ")";
+            $str = "\\Yii::t('" . $this->messageCategory . "', '" . $string . "'" . $ph . ")";
         } else {
             // No I18N, replace placeholders by real words, if any
             if (!empty($placeholders)) {


### PR DESCRIPTION
Class 'common\modules\mediating\models\Yii' not found
    \* @inheritdoc
     */
    public function attributeLabels()
    {
        return [
            'id'            => Yii::t('app', 'ID'),
            'gallery_id'    => Yii::t('app', 'Gallery ID'),
            'image_id'      => Yii::t('app', 'Image ID'),
            'sort_order'    => Yii::t('app', 'Sort Order'),
            'favorit'       => Yii::t('app', 'Favorit'),
            'favorit_order' => Yii::t('app', 'Favorit Order'),
2. yii\base\Application::handleFatalError()
