### PR TITLE
Added ability to generate dropdown from Enum field

### DIFF
--- a/generators/crud/Generator.php
+++ b/generators/crud/Generator.php
@@ -247,7 +247,14 @@ class Generator extends \yii\gii\Generator
             } else {
                 $input = 'textInput';
             }
-            if ($column->phpType !== 'string' || $column->size === null) {
+            if(is_array($column->enumValues) && count($column->enumValues) > 0){
+                $dropDownOptions = "'' => '', ";
+                foreach ($column->enumValues as $enumValue)
+                {
+                    $dropDownOptions .= "'".$enumValue."' => '".$enumValue."', ";
+                }
+                return "\$form->field(\$model, '$attribute')->dropDownList([".$dropDownOptions."])";
+            } else if ($column->phpType !== 'string' || $column->size === null) {
                 return "\$form->field(\$model, '$attribute')->$input()";
             } else {
                 return "\$form->field(\$model, '$attribute')->$input(['maxlength' => $column->size])";


### PR DESCRIPTION
Alternatively, if statement could be: if(substr($column->dbType, 0, 4) === 'enum'), however expected implemented option to be more robust across other database formats.

Created after followup on this issue:  https://github.com/yiisoft/yii/issues/292#issuecomment-44780779
