### PR TITLE
Filter bug in CRUD Search model generator

### DIFF
--- a/generators/crud/default/search.php
+++ b/generators/crud/default/search.php
@@ -70,7 +70,9 @@ class <?= $searchModelClass ?> extends <?= isset($modelAlias) ? $modelAlias : $m
         ]);
 
         if (!($this->load($params) && $this->validate())) {
-            return $dataProvider;
+            foreach ($this->errors as $attribute => $error) {
+                $this->$attribute = '';
+            }
         }
 
         <?= implode("\n        ", $searchConditions) ?>


### PR DESCRIPTION
when i set some attribute by deffault it's filtering by him, but if i put into filter not available value, after $this->validate() return false and search method return my $dataProvider whitout any filter, and show all data but it's not correct, i think if you set in filter incorrect data and other correct data, search method must apply correct filter data, and where incorrect data show error, but now if one data incorrect, search method think that all data incorrect and show all record from db.
