### PR TITLE
Fix issue when using gii with prettyUrl disabled

### DIFF
--- a/views/default/view.php
+++ b/views/default/view.php
@@ -28,6 +28,7 @@ foreach ($generator->templates as $name => $path) {
     <?php $form = ActiveForm::begin([
         'id' => "$id-generator",
         'successCssClass' => '',
+        'action' => Yii::$app->request->url . "?" . Yii::$app->request->queryString,
         'fieldConfig' => ['class' => ActiveField::className()],
     ]); ?>
         <div class="row">


### PR DESCRIPTION
Whenever there is a submit form action, the url would be back to index.
In the case of prettyUrl disabled, the url of index.php?r=gii would always return to index.php, in effect this disables code generation.

The fix adds an action the includes the whole url, so it would send it back to it's current page.
