### PR TITLE
Option to define path to save model files

### DIFF
--- a/assets/gii.js
+++ b/assets/gii.js
@@ -241,6 +241,11 @@ yii.gii = (function ($) {
                 $('form .field-generator-querybaseclass').toggle($(this).is(':checked'));
             }).change();
 
+            // use alias path: toggle base path field
+            $('form #generator-usealiaspath').change(function () {
+                $('form .field-generator-basepath').toggle(!$(this).is(':checked'));
+            }).change();
+
             // hide message category when I18N is disabled
             $('form #generator-enablei18n').change(function () {
                 $('form .field-generator-messagecategory').toggle($(this).is(':checked'));

--- a/generators/model/form.php
+++ b/generators/model/form.php
@@ -16,4 +16,6 @@ echo $form->field($generator, 'queryNs');
 echo $form->field($generator, 'queryClass');
 echo $form->field($generator, 'queryBaseClass');
 echo $form->field($generator, 'enableI18N')->checkbox();
+echo $form->field($generator, 'useAliasPath')->checkbox();
+echo $form->field($generator, 'basePath');
 echo $form->field($generator, 'messageCategory');


### PR DESCRIPTION
The folder where the files are saved are hardcoded.

This PR adds a field to let the developer choose the folder where to save the files.

By default, the folder is defined as before, using the namespace alias.

A use case: create snapshots of the unchanged original model files.