### PR TITLE
Use consistent case for verb names

### DIFF
--- a/generators/crud/default/controller.php
+++ b/generators/crud/default/controller.php
@@ -51,7 +51,7 @@ class <?= $controllerClass ?> extends <?= StringHelper::basename($generator->bas
             'verbs' => [
                 'class' => VerbFilter::className(),
                 'actions' => [
-                    'delete' => ['post'],
+                    'delete' => ['POST'],
                 ],
             ],
         ];


### PR DESCRIPTION
Look for example \yii\rest\ActiveController::verbs