### PR TITLE
Update form.php

### DIFF
--- a/generators/model/form.php
+++ b/generators/model/form.php
@@ -17,3 +17,4 @@ echo $form->field($generator, 'queryClass');
 echo $form->field($generator, 'queryBaseClass');
 echo $form->field($generator, 'enableI18N')->checkbox();
 echo $form->field($generator, 'messageCategory');
+echo $form->field($generator, 'useSchemaName')->checkbox();


### PR DESCRIPTION


I do not wish to have the schema name/database name added to my class name when generating relation classes. I believe this was the older functionality. I tracked down the fix needed to give the user the option and it appears when the "useSchemaName" option was added to the gii Generator somebody forgot to update the view in vendor/yiisoft/yii2-gii/generators/model/form.php to include the line.

echo $form->field($generator, 'useSchemaName')->checkbox();

Adding that one line in vendor/yiisoft/yii2-gii/generators/model/form.php will give the user the option to include or not the schema name in class generation. The label and hints were already coded.
