### PR TITLE
Support composite fk junction tables

### DIFF
--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -24,51 +24,65 @@ class SchemaTest extends GiiTestCase
             $this->markTestSkipped('This feature is only available since Yii 2.0.4.');
         }
 
-        $this->assertEquals(2, count($files));
-        $this->assertEquals("Schema1Table1", basename($files[0]->path, '.php'));
-        $this->assertEquals("Schema1Table2", basename($files[1]->path, '.php'));
+        $this->assertEquals(5, count($files));
+        $this->assertEquals("Schema1Table1", basename($files[3]->path, '.php'));
+        $this->assertEquals("Schema1Table2", basename($files[4]->path, '.php'));
     }
 
-    public function testRelationsGenerator()
+    public function relationsProvider()
+    {
+        return [
+            ['default', 'schema1.*', 5, [
+                0 => [ // relations from junction1 table
+                    "\$this->hasOne(Schema1Table1::className(), ['id' => 'table1_id']);",
+                    "\$this->hasOne(Schema1MultiPk::className(), ['id1' => 'multi_pk_id1', 'id2' => 'multi_pk_id2']);",
+                ],
+                2 => [ // relations from multi_pk table
+                    "\$this->hasMany(Schema1Table1::className(), ['id' => 'table1_id'])->viaTable('junction1', ['multi_pk_id1' => 'id1', 'multi_pk_id2' => 'id2']);",
+                    "\$this->hasMany(Schema1Junction1::className(), ['multi_pk_id1' => 'id1', 'multi_pk_id2' => 'id2']);",
+                ],
+                3 => [ // relations from table1 table
+                    "\$this->hasMany(Schema2Table1::className(), ['fk1' => 'fk2', 'fk2' => 'fk1']);",
+                    "\$this->hasMany(Schema2Table1::className(), ['fk3' => 'fk4', 'fk4' => 'fk3']);",
+                    "\$this->hasOne(Schema2Table2::className(), ['fk1' => 'fk1', 'fk2' => 'fk2']);",
+                    "\$this->hasMany(Schema1MultiPk::className(), ['id1' => 'multi_pk_id1', 'id2' => 'multi_pk_id2'])->viaTable('junction1', ['table1_id' => 'id']);",
+                    "\$this->hasMany(Schema1Junction1::className(), ['table1_id' => 'id']);",
+                ],
+            ]],
+            ['default', 'schema2.*', 2, [
+                0 => [
+                    "\$this->hasOne(Schema1Table1::className(), ['fk2' => 'fk1', 'fk1' => 'fk2']);",
+                    "\$this->hasOne(Schema1Table1::className(), ['fk4' => 'fk3', 'fk3' => 'fk4']);",
+                    "\$this->hasOne(Schema2Table2::className(), ['fk5' => 'fk5', 'fk6' => 'fk6']);",
+                ],
+            ]],
+        ];
+    }
+
+    /**
+     * @dataProvider relationsProvider
+     */
+    public function testRelationsGenerator($template, $tableName, $filesCount, $relationSets)
     {
         $generator = new ModelGenerator();
-        $generator->template = 'default';
-        $generator->tableName = 'schema1.*';
+        $generator->template = $template;
+        $generator->tableName = $tableName;
 
         $files = $generator->generate();
-        $this->assertEquals(2, count($files));
-        $modelCode = $files[0]->content;
-        $modelClass = basename($files[0]->path, '.php');
+        $this->assertEquals($filesCount, count($files));
 
-        if (version_compare(str_replace('-dev', '', Yii::getVersion()), '2.0.4', '<')) {
-            $this->markTestSkipped('This feature is only available since Yii 2.0.4.');
-        }
+        foreach ($relationSets as $index => $relations) {
+            $modelCode = $files[$index]->content;
+            $modelClass = basename($files[$index]->path, '.php');
 
-        $relations = [
-            "\$this->hasMany(Schema2Table1::className(), ['fk1' => 'fk2', 'fk2' => 'fk1']);",
-            "\$this->hasMany(Schema2Table1::className(), ['fk3' => 'fk4', 'fk4' => 'fk3']);",
-            "\$this->hasOne(Schema2Table2::className(), ['fk1' => 'fk1', 'fk2' => 'fk2']);",
-        ];
-        foreach ($relations as $relation) {
-            $this->assertTrue(strpos($modelCode, $relation) !== false, "Model $modelClass should contain this relation: $relation.\n$modelCode");
-        }
+            if (version_compare(str_replace('-dev', '', Yii::getVersion()), '2.0.4', '<')) {
+                $this->markTestSkipped('This feature is only available since Yii 2.0.4.');
+            }
 
-        $generator = new ModelGenerator();
-        $generator->template = 'default';
-        $generator->tableName = 'schema2.*';
-
-        $files = $generator->generate();
-        $this->assertEquals(2, count($files));
-        $modelCode = $files[0]->content;
-        $modelClass = basename($files[0]->path, '.php');
-
-        $relations = [
-            "\$this->hasOne(Schema1Table1::className(), ['fk2' => 'fk1', 'fk1' => 'fk2']);",
-            "\$this->hasOne(Schema1Table1::className(), ['fk4' => 'fk3', 'fk3' => 'fk4']);",
-            "\$this->hasOne(Schema2Table2::className(), ['fk5' => 'fk5', 'fk6' => 'fk6']);",
-        ];
-        foreach ($relations as $relation) {
-            $this->assertTrue(strpos($modelCode, $relation) !== false, "Model $modelClass should contain this relation: $relation.\n$modelCode");
+            foreach ($relations as $relation) {
+                $this->assertTrue(strpos($modelCode, $relation) !== false,
+                    "Model $modelClass should contain this relation: $relation.\n$modelCode");
+            }
         }
     }
 }

--- a/tests/data/pgsql.sql
+++ b/tests/data/pgsql.sql
@@ -7,6 +7,9 @@ DROP TABLE IF EXISTS "schema1"."table1" CASCADE;
 DROP TABLE IF EXISTS "schema1"."table2" CASCADE;
 DROP TABLE IF EXISTS "schema2"."table1" CASCADE;
 DROP TABLE IF EXISTS "schema2"."table2" CASCADE;
+DROP TABLE IF EXISTS "schema1"."multi_pk" CASCADE;
+DROP TABLE IF EXISTS "schema1"."junction1" CASCADE;
+DROP TABLE IF EXISTS "schema1"."junction2" CASCADE;
 DROP SCHEMA IF EXISTS "schema1" CASCADE;
 DROP SCHEMA IF EXISTS "schema2" CASCADE;
 
@@ -30,6 +33,31 @@ CREATE TABLE "schema1"."table2" (
   fk1 integer not null,
   fk2 integer not null,
   UNIQUE (fk1, fk2)
+);
+
+CREATE TABLE "schema1"."multi_pk" (
+  id1 integer not null,
+  id2 integer not null,
+  PRIMARY KEY (id1, id2)
+);
+
+CREATE TABLE "schema1"."junction1" (
+  multi_pk_id1 integer not null,
+  multi_pk_id2 integer not null,
+  table1_id integer not null,
+  PRIMARY KEY (multi_pk_id1, multi_pk_id2, table1_id),
+  CONSTRAINT j1_multi_pk_fkey FOREIGN KEY (multi_pk_id1, multi_pk_id2) REFERENCES "schema1"."multi_pk" (id1, id2),
+  CONSTRAINT j1_table1_fkey FOREIGN KEY (table1_id) REFERENCES "schema1"."table1" (id)
+);
+
+CREATE TABLE "schema1"."junction2" (
+  multi_pk_id1 integer not null,
+  multi_pk_id2 integer not null,
+  table1_id integer not null,
+  data text,
+  PRIMARY KEY (multi_pk_id1, multi_pk_id2, table1_id),
+  CONSTRAINT j1_multi_pk_fkey FOREIGN KEY (multi_pk_id1, multi_pk_id2) REFERENCES "schema1"."multi_pk" (id1, id2),
+  CONSTRAINT j1_table1_fkey FOREIGN KEY (table1_id) REFERENCES "schema1"."table1" (id)
 );
 
 CREATE TABLE "schema2"."table1" (


### PR DESCRIPTION
Resolves #20.

Refactored all _pivot_ occurences to _junction_.

Added support for composite (multi-column) foreign keys in junction tables.

Is also affected by yiisoft/yii2#9731