### PR TITLE
Removed redundant return in active() scope example

### DIFF
--- a/generators/model/default/query.php
+++ b/generators/model/default/query.php
@@ -33,8 +33,7 @@ class <?= $className ?> extends <?= '\\' . ltrim($generator->queryBaseClass, '\\
 {
     /*public function active()
     {
-        $this->andWhere('[[status]]=1');
-        return $this;
+        return $this->andWhere('[[status]]=1');
     }*/
 
     /**


### PR DESCRIPTION
We can just return `$this->andWhere`, [official docs reference](http://www.yiiframework.com/doc-2.0/guide-db-active-record.html#customizing-query-classes).