### PR TITLE
Use table comments for documentor's variable description

### DIFF
--- a/generators/model/Generator.php
+++ b/generators/model/Generator.php
@@ -36,6 +36,7 @@ class Generator extends \yii\gii\Generator
     public $baseClass = 'yii\db\ActiveRecord';
     public $generateRelations = self::RELATIONS_ALL;
     public $generateLabelsFromComments = false;
+    public $generateDocsFromComments = false;
     public $useTablePrefix = false;
     public $useSchemaName = true;
     public $generateQuery = false;
@@ -80,7 +81,7 @@ class Generator extends \yii\gii\Generator
             [['baseClass'], 'validateClass', 'params' => ['extends' => ActiveRecord::className()]],
             [['queryBaseClass'], 'validateClass', 'params' => ['extends' => ActiveQuery::className()]],
             [['generateRelations'], 'in', 'range' => [self::RELATIONS_NONE, self::RELATIONS_ALL, self::RELATIONS_ALL_INVERSE]],
-            [['generateLabelsFromComments', 'useTablePrefix', 'useSchemaName', 'generateQuery'], 'boolean'],
+            [['generateLabelsFromComments', 'generateDocsFromComments', 'useTablePrefix', 'useSchemaName', 'generateQuery'], 'boolean'],
             [['enableI18N'], 'boolean'],
             [['messageCategory'], 'validateMessageCategory', 'skipOnEmpty' => false],
         ]);
@@ -99,6 +100,7 @@ class Generator extends \yii\gii\Generator
             'baseClass' => 'Base Class',
             'generateRelations' => 'Generate Relations',
             'generateLabelsFromComments' => 'Generate Labels from DB Comments',
+            'generateDocsFromComments' => 'Generate model\'s propeties descriptions from DB Comments',
             'generateQuery' => 'Generate ActiveQuery',
             'queryNs' => 'ActiveQuery Namespace',
             'queryClass' => 'ActiveQuery Class',
@@ -131,6 +133,8 @@ class Generator extends \yii\gii\Generator
                 you may want to uncheck this option to accelerate the code generation process.',
             'generateLabelsFromComments' => 'This indicates whether the generator should generate attribute labels
                 by using the comments of the corresponding DB columns.',
+            'generateDocsFromComments' => 'This indicates whether the generator should generate description
+                for each model\'s @propery by using the comments of the corresponding DB columns.',
             'useTablePrefix' => 'This indicates whether the table name returned by the generated ActiveRecord class
                 should consider the <code>tablePrefix</code> setting of the DB connection. For example, if the
                 table name is <code>tbl_post</code> and <code>tablePrefix=tbl_</code>, the ActiveRecord class
@@ -177,7 +181,7 @@ class Generator extends \yii\gii\Generator
      */
     public function stickyAttributes()
     {
-        return array_merge(parent::stickyAttributes(), ['ns', 'db', 'baseClass', 'generateRelations', 'generateLabelsFromComments', 'queryNs', 'queryBaseClass']);
+        return array_merge(parent::stickyAttributes(), ['ns', 'db', 'baseClass', 'generateRelations', 'generateLabelsFromComments', 'generateDocsFromComments', 'queryNs', 'queryBaseClass']);
     }
 
     /**

--- a/generators/model/default/model.php
+++ b/generators/model/default/model.php
@@ -24,7 +24,7 @@ use Yii;
  * This is the model class for table "<?= $generator->generateTableName($tableName) ?>".
  *
 <?php foreach ($tableSchema->columns as $column): ?>
- * @property <?= "{$column->phpType} \${$column->name}\n" ?>
+ * @property <?= "{$column->phpType} \${$column->name}" . ($generator->generateDocsFromComments ? " {$column->comment}" : '') . "\n" ?>
 <?php endforeach; ?>
 <?php if (!empty($relations)): ?>
  *

--- a/generators/model/form.php
+++ b/generators/model/form.php
@@ -18,6 +18,7 @@ echo $form->field($generator, 'generateRelations')->dropDownList([
     Generator::RELATIONS_ALL_INVERSE => 'All relations with inverse',
 ]);
 echo $form->field($generator, 'generateLabelsFromComments')->checkbox();
+echo $form->field($generator, 'generateDocsFromComments')->checkbox();
 echo $form->field($generator, 'generateQuery')->checkbox();
 echo $form->field($generator, 'queryNs');
 echo $form->field($generator, 'queryClass');


### PR DESCRIPTION
Hello!

I am using PHPdoc comments a lot in my work and in Yii projects I have to copy-paste the db fileds' descriptions into my models, most of which is generated by gii. So, I've made some changes in gii's model generator to use the db comments in model's doc-block.

It's not such a big thing, but may be usefull for those who is using PHPdoc in their IDE.

The changes include generator propery, corresponding checkbox and default model template.
