### PR TITLE
Attribute queryNs on model generator not validate.

### DIFF
--- a/generators/model/Generator.php
+++ b/generators/model/Generator.php
@@ -654,14 +654,17 @@ class Generator extends \yii\gii\Generator
     }
 
     /**
-     * Validates the [[ns]] attribute.
+     * Validates the namespace.
+     *
+     * @param string $attribute Namespace variable.
      */
-    public function validateNamespace()
+    public function validateNamespace($attribute)
     {
-        $this->ns = ltrim($this->ns, '\\');
-        $path = Yii::getAlias('@' . str_replace('\\', '/', $this->ns), false);
+        $value = $this->$attribute;
+        $value = ltrim($value, '\\');
+        $path = Yii::getAlias('@' . str_replace('\\', '/', $value), false);
         if ($path === false) {
-            $this->addError('ns', 'Namespace must be associated with an existing directory.');
+            $this->addError($attribute, 'Namespace must be associated with an existing directory.');
         }
     }
 

--- a/tests/ModelGeneratorTest.php
+++ b/tests/ModelGeneratorTest.php
@@ -15,6 +15,14 @@ class ModelGeneratorTest extends GiiTestCase
         $generator->template = 'default';
         $generator->tableName = '*';
 
+        $generator->queryNs = 'application\models';
+
+        $valid = $generator->validate();
+        $this->assertFalse($valid);
+        $this->assertEquals($generator->getFirstError('queryNs'), 'Namespace must be associated with an existing directory.');
+
+        $generator->queryNs = 'app\models';
+
         $valid = $generator->validate();
         $this->assertTrue($valid, 'Validation failed: ' . print_r($generator->getErrors(), true));
 


### PR DESCRIPTION
On model generator validate only ns attribute. Fixed. Unit test added.