### PR TITLE
fix generating model without any rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 gii extension Change Log
 -----------------------
 
 - Bug #149: Relation names no longer override existing methods and properties (Faryshta)
+- Bug #152: Fixed generating model without any rules (and800)
 
 
 2.0.5 March 18, 2016

--- a/generators/model/default/model.php
+++ b/generators/model/default/model.php
@@ -58,7 +58,7 @@ class <?= $className ?> extends <?= '\\' . ltrim($generator->baseClass, '\\') . 
      */
     public function rules()
     {
-        return [<?= "\n            " . implode(",\n            ", $rules) . ",\n        " ?>];
+        return [<?= empty($rules) ? '' : ("\n            " . implode(",\n            ", $rules) . ",\n        ") ?>];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Fix generating `return [,];` in model's `rules()` property when no rules have been created.