### PR TITLE
Changed label of attribute: Model Class Name

### DIFF
--- a/generators/model/Generator.php
+++ b/generators/model/Generator.php
@@ -96,7 +96,7 @@ class Generator extends \yii\gii\Generator
             'ns' => 'Namespace',
             'db' => 'Database Connection ID',
             'tableName' => 'Table Name',
-            'modelClass' => 'Model Class',
+            'modelClass' => 'Model Class Name',
             'baseClass' => 'Base Class',
             'generateRelations' => 'Generate Relations',
             'generateLabelsFromComments' => 'Generate Labels from DB Comments',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no

It sound clearer than "Model Class" which associating with `app\models\Blablabla`. For example, in CRUD generator the "Model Class" mean fully qualified class name, and here this mean class name, not fully qualified.
