### PR TITLE
Add missing indentation and newlines for crud Pjax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 gii extension Change Log
 - Bug #126, #139: Fixed model generator form validation when "ActiveQuery Class" is invalid but unused (kikimor)
 - Enh #167: Added option for generating relations from current schema only (zlakomanoff)
 - Bug #166: Fixed "Trying to get property of non-object" during model generation (zlakomanoff)
+- Bug #179: Fixed indentation and newlines for Pjax widget in crud index view (nkovacs)
 
 2.0.5 March 18, 2016
 --------------------

--- a/generators/crud/default/views/index.php
+++ b/generators/crud/default/views/index.php
@@ -33,7 +33,7 @@ $this->params['breadcrumbs'][] = $this->title;
     <p>
         <?= "<?= " ?>Html::a(<?= $generator->generateString('Create ' . Inflector::camel2words(StringHelper::basename($generator->modelClass))) ?>, ['create'], ['class' => 'btn btn-success']) ?>
     </p>
-<?= $generator->enablePjax ? '<?php Pjax::begin(); ?>' : '' ?>
+<?= $generator->enablePjax ? "    <?php Pjax::begin(); ?>\n" : '' ?>
 <?php if ($generator->indexWidgetType === 'grid'): ?>
     <?= "<?= " ?>GridView::widget([
         'dataProvider' => $dataProvider,
@@ -74,5 +74,5 @@ if (($tableSchema = $generator->getTableSchema()) === false) {
         },
     ]) ?>
 <?php endif; ?>
-<?= $generator->enablePjax ? '<?php Pjax::end(); ?>' : '' ?>
+<?= $generator->enablePjax ? "    <?php Pjax::end(); ?>\n" : '' ?>
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #179 

This change indents `Pjax::begin` and `Pjax::end` to the same depth
as the index widget, and adds a newline after them because the closing
php tag swallows the one after it.

Fixes #179