### PR TITLE
`yii\gii\Module::defaultVersion()` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 gii extension Change Log
 - Bug #186: Fixed incorrect database name exception (zlakomanoff)
 - Bug #200: Fixed Pjax and Listview with CRUD generator (ariestattoo)
 - Chg: Updated version constraint for `yiisoft/yii2` in extension template to `~2.0.0` to ensure compatibility when 2.1 is released (cebe)
+- Enh: `yii\gii\Module::defaultVersion()` implemented to pick up 'yiisoft/yii2-gii' extension version (klimov-paul)
 
 2.0.5 March 18, 2016
 --------------------

--- a/Module.php
+++ b/Module.php
@@ -9,6 +9,7 @@ namespace yii\gii;
 
 use Yii;
 use yii\base\BootstrapInterface;
+use yii\helpers\Json;
 use yii\web\ForbiddenHttpException;
 
 /**
@@ -165,5 +166,19 @@ class Module extends \yii\base\Module implements BootstrapInterface
             'module' => ['class' => 'yii\gii\generators\module\Generator'],
             'extension' => ['class' => 'yii\gii\generators\extension\Generator'],
         ];
+    }
+
+    /**
+     * @inheritdoc
+     * @since 2.0.6
+     */
+    protected function defaultVersion()
+    {
+        $packageInfo = Json::decode(file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'composer.json'));
+        $extensionName = $packageInfo['name'];
+        if (isset(Yii::$app->extensions[$extensionName])) {
+            return Yii::$app->extensions[$extensionName]['version'];
+        }
+        return parent::defaultVersion();
     }
 }

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace yiiunit\extensions\gii;
+
+use Yii;
+use yii\gii\Module;
+
+class ModuleTest extends TestCase
+{
+    public function testDefaultVersion()
+    {
+        Yii::$app->extensions['yiisoft/yii2-gii'] = [
+            'name' => 'yiisoft/yii2-gii',
+            'version' => '2.0.6',
+        ];
+
+        $module = new Module('gii');
+
+        $this->assertEquals('2.0.6', $module->getVersion());
+    }
+}


### PR DESCRIPTION
Extracted from https://github.com/yiisoft/yii2/issues/12726

`yii\gii\Module::defaultVersion()` implemented to pick up 'yiisoft/yii2-gii' extension version

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes