### PR TITLE
Fixed a bulk model generation bug.

### DIFF
--- a/generators/model/Generator.php
+++ b/generators/model/Generator.php
@@ -801,11 +801,15 @@ class Generator extends \yii\gii\Generator
         $patterns[] = "/^{$db->tablePrefix}(.*?)$/";
         $patterns[] = "/^(.*?){$db->tablePrefix}$/";
         if (strpos($this->tableName, '*') !== false) {
-            $pattern = $this->tableName;
-            if (($pos = strrpos($pattern, '.')) !== false) {
-                $pattern = substr($pattern, $pos + 1);
+            $bulkPattern = $this->tableName;
+            if (($pos = strrpos($bulkPattern, '.')) !== false) {
+                $bulkPattern = substr($bulkPattern, $pos + 1);
             }
-            $patterns[] = '/^' . str_replace('*', '(\w+)', $pattern) . '$/';
+            $bulkPattern = '/^' . str_replace('*', '(\w+)', $bulkPattern) . '$/';
+            if (preg_match($bulkPattern, $tableName, $matches)) {
+                $className = $matches[1];
+				return $this->classNames[$fullTableName] = Inflector::id2camel($schemaName.$className, '_');
+            }
         }
         $className = $tableName;
         foreach ($patterns as $pattern) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no

It now _actually_ works as it is stated in the hint on table name field.
For example, table tbl_post will generate Post class, if the tableName field contains "tbl_*" pattern.
I'm actually surprised by the age of this bug. Nobody wanted to use that feature? :laughing: 