### PR TITLE
Issue #64 Generate 'skipOnEmpty' => false for 'exist' rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.6 under development
 -----------------------
 
+- Enh #64: Add "skipOnEmpty => false" to generated model exist rule if referrer foreign key column is NOT NULL (MKiselev)
 - Enh #234: Changed submit button label from "Update" and "Create" to "Save" (MKiselev)
 - Bug #232: Fixed Help documentation link (drdim)
 - Enh #230: Allowed underscores for extension namespaces (Nex Otaku)

--- a/generators/model/Generator.php
+++ b/generators/model/Generator.php
@@ -354,12 +354,22 @@ class Generator extends \yii\gii\Generator
             $refClassName = $this->generateClassName($refTable);
             unset($refs[0]);
             $attributes = implode("', '", array_keys($refs));
+
+            // https://github.com/yiisoft/yii2-gii/issues/64
+            $skipOnEmpty = true;
+            foreach (array_keys($refs) as $refColumnName) {
+                if(!$table->columns[$refColumnName]->allowNull === false) {
+                    $skipOnEmpty = false;
+                }
+            }
+
             $targetAttributes = [];
             foreach ($refs as $key => $value) {
                 $targetAttributes[] = "'$key' => '$value'";
             }
             $targetAttributes = implode(', ', $targetAttributes);
-            $rules[] = "[['$attributes'], 'exist', 'skipOnError' => true, 'targetClass' => $refClassName::className(), 'targetAttribute' => [$targetAttributes]]";
+
+            $rules[] = "[['$attributes'], 'exist', 'skipOnError' => true, 'targetClass' => $refClassName::className(), 'targetAttribute' => [$targetAttributes]" . ($skipOnEmpty ? '' : ', \'skipOnEmpty\' => false') . "]";
         }
 
         return $rules;


### PR DESCRIPTION
Generate 'skipOnEmpty' => false for 'exist' rule based on foreign keys when column NOT NULL

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #64 