### PR TITLE
travis PHPUnit 6.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 install:
   - travis_retry composer self-update && composer --version
-  - travis_retry composer global require "fxp/composer-asset-plugin:^1.2.0"
+  - travis_retry composer global require "fxp/composer-asset-plugin:^1.2.0" "phpunit/phpunit"
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - travis_retry composer install --prefer-dist --no-interaction
   - composer show -i

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,7 @@ use Yii;
 /**
  * This is the base class for all yii framework unit tests.
  */
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * Clean up after test.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

Travis test for php7 use PHPUnit 6.x by default and tests failed.

Release Announcement for PHPUnit 6.0.0:
PHPUnit's units of code are now namespaced. For instance, PHPUnit_Framework_TestCase is now PHPUnit\Framework\TestCase