### PR TITLE
Update nav link on main.php

### DIFF
--- a/views/layouts/main.php
+++ b/views/layouts/main.php
@@ -32,7 +32,7 @@ $asset = yii\gii\GiiAsset::register($this);
             'options' => ['class' => 'nav navbar-nav navbar-right'],
             'items' => [
                 ['label' => 'Home', 'url' => ['default/index']],
-                ['label' => 'Help', 'url' => 'http://www.yiiframework.com/doc-2.0/ext-gii-index.html'],
+                ['label' => 'Help', 'url' => 'https://github.com/yiisoft/yii2-gii/blob/master/docs/guide/README.md'],
                 ['label' => 'Application', 'url' => Yii::$app->homeUrl],
             ],
         ]);


### PR DESCRIPTION
old link gets error on yiiframework.com site: "Unable to resolve the request "doc-2.0/guide-tool-gii.html"."
Change to actual docs url.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | not tested it
| Fixed issues  | link in gii navpanel are not actually. Fixed.
