### PR TITLE
Fix an invalid type hint in a model template

### DIFF
--- a/generators/model/default/model.php
+++ b/generators/model/default/model.php
@@ -76,7 +76,7 @@ class <?= $className ?> extends <?= '\\' . ltrim($generator->baseClass, '\\') . 
 <?php foreach ($relations as $name => $relation): ?>
 
     /**
-     * @return \yii\db\ActiveQuery
+     * @return \yii\db\ActiveQueryInterface
      */
     public function get<?= $name ?>()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

I may be missing something but it seems to me that `ActiveQueryInterface` would be more precise here since `\yii\db\BaseActiveRecord` [checks for it specifically](https://github.com/yiisoft/yii2/blob/master/framework/db/BaseActiveRecord.php#L286).

```php
    public function __get($name)
    {
        if (isset($this->_attributes[$name]) || array_key_exists($name, $this->_attributes)) {
            return $this->_attributes[$name];
        } elseif ($this->hasAttribute($name)) {
            return null;
        } else {
            if (isset($this->_related[$name]) || array_key_exists($name, $this->_related)) {
                return $this->_related[$name];
            }
            $value = parent::__get($name);
            if ($value instanceof ActiveQueryInterface) {
                return $this->_related[$name] = $value->findFor($name, $this);
            } else {
                return $value;
            }
        }
    }
```

**Related:** Am I right that these type hints([1](https://github.com/yiisoft/yii2/blob/master/framework/db/BaseActiveRecord.php#L410), [2](https://github.com/yiisoft/yii2/blob/master/framework/db/BaseActiveRecord.php#L369)) are invalid too and should read as `ActiveQuery`?