### PR TITLE
missing attribute in stickyAttributes

### DIFF
--- a/generators/model/Generator.php
+++ b/generators/model/Generator.php
@@ -180,7 +180,7 @@ class Generator extends \yii\gii\Generator
      */
     public function stickyAttributes()
     {
-        return array_merge(parent::stickyAttributes(), ['ns', 'db', 'baseClass', 'generateRelations', 'generateLabelsFromComments', 'queryNs', 'queryBaseClass']);
+        return array_merge(parent::stickyAttributes(), ['ns', 'db', 'baseClass', 'generateRelations', 'generateLabelsFromComments', 'queryNs', 'queryBaseClass', 'useTablePrefix', 'generateQuery']);
     }
 
     /**


### PR DESCRIPTION
add “useTablePrefix” and “generateQuery” for stickyAttributes

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no no
| New feature?  | yes/no no
| Breaks BC?    | yes/no no
| Tests pass?   | yes/no yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
