### PR TITLE
Fix: Generate model name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.6 under development
 -----------------------
 
+- Bug #290: Fixed model name generator when nothing happend on submit if enter schem.tabel (SwoDs)
 - Bug #198: Fixed false-positive detection of URL fields in CRUD generator (cebe)
 - Bug #255: Fixed error when getting database driver name when db is not an instance of `yii\db\Connection` (MKiselev)
 - Bug #97: Fixed errors and wrong directories created when using backslash in view paths and output paths of CRUD, Controller and Extension generators (lubosdz, samdark)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.6 under development
 -----------------------
 
-- Bug #290: Fixed model name generator when nothing happend on submit if enter schem.table (SwoDs)
+- Bug #290: Fixed model generator to work properly with `schema.table` as table name (SwoDs)
 - Bug #198: Fixed false-positive detection of URL fields in CRUD generator (cebe)
 - Bug #255: Fixed error when getting database driver name when db is not an instance of `yii\db\Connection` (MKiselev)
 - Bug #97: Fixed errors and wrong directories created when using backslash in view paths and output paths of CRUD, Controller and Extension generators (lubosdz, samdark)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.6 under development
 -----------------------
 
-- Bug #290: Fixed model name generator when nothing happend on submit if enter schem.tabel (SwoDs)
+- Bug #290: Fixed model name generator when nothing happend on submit if enter schem.table (SwoDs)
 - Bug #198: Fixed false-positive detection of URL fields in CRUD generator (cebe)
 - Bug #255: Fixed error when getting database driver name when db is not an instance of `yii\db\Connection` (MKiselev)
 - Bug #97: Fixed errors and wrong directories created when using backslash in view paths and output paths of CRUD, Controller and Extension generators (lubosdz, samdark)

--- a/assets/gii.js
+++ b/assets/gii.js
@@ -240,7 +240,7 @@ yii.gii = (function ($) {
                 }
                 if ($('#generator-modelclass').val() === '' && tableName && tableName.indexOf('*') === -1) {
                     var modelClass = '';
-                    $.each(tableName.split('_'), function() {
+                    $.each(tableName.split(/\.|\_/), function() {
                         if(this.length>0)
                             modelClass+=this.substring(0,1).toUpperCase()+this.substring(1);
                     });


### PR DESCRIPTION
When you use PostgreSQL and typing with schema name you will get error in modelClass and queryClass field, if the checkbox of the generateQuery will be unset you won't see any errors but nothing happend, form won't be send

При использовании PostgreSQL если вписать название таблицы вместе со схемой то значение поля будет перенесено в modelClass и queryClass криво (к примеру: user.log получим User.log, но точку в названии модели использовать нельзя), но если modelClass мы видим сразу и правим ошибку, то queryClass скрыто по умолчанию и ошибку не видно из-за чего при нажатии на preview ничего не произойдет

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
