### PR TITLE
autoformat

### DIFF
--- a/tests/GiiTestCase.php
+++ b/tests/GiiTestCase.php
@@ -22,21 +22,21 @@ class GiiTestCase extends TestCase
         $allConfigs = require(__DIR__ . '/data/config.php');
 
         $config = $allConfigs['databases'][$this->driverName];
-        $pdo_database = 'pdo_'.$this->driverName;
+        $pdo_database = 'pdo_' . $this->driverName;
 
         if (!extension_loaded('pdo') || !extension_loaded($pdo_database)) {
-            $this->markTestSkipped('pdo and '.$pdo_database.' extension are required.');
+            $this->markTestSkipped('pdo and ' . $pdo_database . ' extension are required.');
         }
 
         $this->mockApplication([
-           'components' => [
-               'db' => [
-                   'class' => isset($config['class']) ? $config['class'] : 'yii\db\Connection',
-                   'dsn' => $config['dsn'],
-                   'username' => isset($config['username']) ? $config['username'] : null,
-                   'password' => isset($config['password']) ? $config['password'] : null,
-               ],
-           ],
+            'components' => [
+                'db' => [
+                    'class' => isset($config['class']) ? $config['class'] : 'yii\db\Connection',
+                    'dsn' => $config['dsn'],
+                    'username' => isset($config['username']) ? $config['username'] : null,
+                    'password' => isset($config['password']) ? $config['password'] : null,
+                ],
+            ],
         ]);
 
         if (isset($config['fixture'])) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,10 +45,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             'components' => [
                 'request' => [
                     'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
-                    'scriptFile' => __DIR__ .'/index.php',
+                    'scriptFile' => __DIR__ . '/index.php',
                     'scriptUrl' => '/index.php',
                 ],
-            ]
+            ],
         ], $config));
     }
 

--- a/tests/compatibility.php
+++ b/tests/compatibility.php
@@ -4,14 +4,19 @@
  */
 
 namespace PHPUnit\Framework\Constraint {
+
     if (!class_exists('PHPUnit\Framework\Constraint\Constraint') && class_exists('PHPUnit_Framework_Constraint')) {
-        abstract class Constraint extends \PHPUnit_Framework_Constraint {}
+        abstract class Constraint extends \PHPUnit_Framework_Constraint
+        {
+        }
     }
 }
 
 namespace PHPUnit\Framework {
+
     if (!class_exists('PHPUnit\Framework\TestCase') && class_exists('PHPUnit_Framework_TestCase')) {
-        abstract class TestCase extends \PHPUnit_Framework_TestCase {
+        abstract class TestCase extends \PHPUnit_Framework_TestCase
+        {
             /**
              * @param string $exception
              */

--- a/tests/data/config.php
+++ b/tests/data/config.php
@@ -6,10 +6,9 @@
  * For example to change PostgreSQL username and password your `config.local.php` should
  * contain the following:
  *
-<?php
-$config['databases']['pgsql']['username'] = 'yiitest';
-$config['databases']['pgsql']['password'] = 'changeme';
-
+ * <?php
+ * $config['databases']['pgsql']['username'] = 'yiitest';
+ * $config['databases']['pgsql']['password'] = 'changeme';
  */
 
 $config = [


### PR DESCRIPTION
Some tests files pass throw IDE autoformat tool. (PSR1/PSR2 + space after (type) + new line before return)

I'm not sure about `{}` after abstract class, please comment it.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no

