### PR TITLE
avoid space after uncomment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.6 under development
 -----------------------
 
-- Chg #300: Remove space from commented attribute lines in CRUD index view. Uncomment this line still make tabs is equal (bscheshirwork)
+- Enh #300: Removed space from commented out code so when uncommenting in IDEs there's no extra spacing (bscheshirwork)
 - Enh #293: Do not generate redundant `else` after `return` (bscheshirwork)
 - Bug #290: Fixed model generator to work properly with `schema.table` as table name (SwoDs)
 - Bug #198: Fixed false-positive detection of URL fields in CRUD generator (cebe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.6 under development
 -----------------------
 
+- Chg #300: Remove space from commented attribute lines in CRUD index view. Uncomment this line still make tabs is equal (bscheshirwork)
 - Enh #293: Do not generate redundant `else` after `return` (bscheshirwork)
 - Bug #290: Fixed model generator to work properly with `schema.table` as table name (SwoDs)
 - Bug #198: Fixed false-positive detection of URL fields in CRUD generator (cebe)

--- a/generators/crud/default/views/index.php
+++ b/generators/crud/default/views/index.php
@@ -48,7 +48,7 @@ if (($tableSchema = $generator->getTableSchema()) === false) {
         if (++$count < 6) {
             echo "            '" . $name . "',\n";
         } else {
-            echo "            // '" . $name . "',\n";
+            echo "           // '" . $name . "',\n";
         }
     }
 } else {
@@ -57,7 +57,7 @@ if (($tableSchema = $generator->getTableSchema()) === false) {
         if (++$count < 6) {
             echo "            '" . $column->name . ($format === 'text' ? "" : ":" . $format) . "',\n";
         } else {
-            echo "            // '" . $column->name . ($format === 'text' ? "" : ":" . $format) . "',\n";
+            echo "           // '" . $column->name . ($format === 'text' ? "" : ":" . $format) . "',\n";
         }
     }
 }

--- a/generators/crud/default/views/index.php
+++ b/generators/crud/default/views/index.php
@@ -48,7 +48,7 @@ if (($tableSchema = $generator->getTableSchema()) === false) {
         if (++$count < 6) {
             echo "            '" . $name . "',\n";
         } else {
-            echo "           // '" . $name . "',\n";
+            echo "            //'" . $name . "',\n";
         }
     }
 } else {
@@ -57,7 +57,7 @@ if (($tableSchema = $generator->getTableSchema()) === false) {
         if (++$count < 6) {
             echo "            '" . $column->name . ($format === 'text' ? "" : ":" . $format) . "',\n";
         } else {
-            echo "           // '" . $column->name . ($format === 'text' ? "" : ":" . $format) . "',\n";
+            echo "            //'" . $column->name . ($format === 'text' ? "" : ":" . $format) . "',\n";
         }
     }
 }


### PR DESCRIPTION
Result:
```php
    <?= GridView::widget([
        'dataProvider' => $dataProvider,
        'filterModel' => $searchModel,
        'columns' => [
            ['class' => 'yii\grid\SerialColumn'],

            'id',
            'attribute2',
            'attribute3',
            'attribute4',
            'attribute5',
           // 'attribute6',
           // 'attribute7',
            ['class' => 'yii\grid\ActionColumn'],
        ],
    ]); ?>

```
```php
    <?= GridView::widget([
        'dataProvider' => $dataProvider,
        'filterModel' => $searchModel,
        'columns' => [
            ['class' => 'yii\grid\SerialColumn'],

            'id',
            'attribute2',
            'attribute3',
            'attribute4',
            'attribute5',
            'attribute6',
            'attribute7',
            ['class' => 'yii\grid\ActionColumn'],
        ],
    ]); ?>

```

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no