### PR TITLE
add generateString to NotFoundHttpException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.6 under development
 -----------------------
 
-- Enh #306: NotFoundHttpException's message in CRUD uses i18n (bscheshirwork)
+- Enh #174: NotFoundHttpException's message in CRUD uses i18n (bscheshirwork)
 - Enh #293: Do not generate redundant `else` after `return` (bscheshirwork)
 - Bug #290: Fixed model generator to work properly with `schema.table` as table name (SwoDs)
 - Bug #198: Fixed false-positive detection of URL fields in CRUD generator (cebe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.6 under development
 -----------------------
 
+- Chg #306: NotFoundHttpException's message in CRUD uses i18n (bscheshirwork)
 - Enh #293: Do not generate redundant `else` after `return` (bscheshirwork)
 - Bug #290: Fixed model generator to work properly with `schema.table` as table name (SwoDs)
 - Bug #198: Fixed false-positive detection of URL fields in CRUD generator (cebe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.6 under development
 -----------------------
 
-- Chg #306: NotFoundHttpException's message in CRUD uses i18n (bscheshirwork)
+- Enh #306: NotFoundHttpException's message in CRUD uses i18n (bscheshirwork)
 - Enh #293: Do not generate redundant `else` after `return` (bscheshirwork)
 - Bug #290: Fixed model generator to work properly with `schema.table` as table name (SwoDs)
 - Bug #198: Fixed false-positive detection of URL fields in CRUD generator (cebe)

--- a/generators/crud/default/controller.php
+++ b/generators/crud/default/controller.php
@@ -171,6 +171,6 @@ if (count($pks) === 1) {
             return $model;
         }
 
-        throw new NotFoundHttpException('The requested page does not exist.');
+        throw new NotFoundHttpException(<?= $generator->generateString('The requested page does not exist.') ?>);
     }
 }


### PR DESCRIPTION
Add dependencies from Yii::t to controller.
not found `The requested page does not exist.` message in category `yii` -- pick message from user-definite message category.


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #174 
