### PR TITLE
Force HTML content type in response to display HTML when app is configured for REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 gii extension Change Log
 
 2.0.6 under development
 -----------------------
-- Bug #317: Force HTML content type in response to display HTML when app is configured for REST API
+- Bug #317: Force HTML content type in response to display HTML when app is configured for REST API (microThread)
 - Enh #315: Make `yii\gii\generators\model\Generator` `generateProperties` protected (claudejanz)
 - Enh #295: Allowed to use aliases in generator's templates (dmirogin)
 - Enh #300: Removed space from commented out code so when uncommenting in IDEs there's no extra spacing (bscheshirwork)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 gii extension Change Log
 
 2.0.6 under development
 -----------------------
-
+- Bug #317: Force HTML content type in response to display HTML when app is configured for REST API
 - Enh #315: Make `yii\gii\generators\model\Generator` `generateProperties` protected (claudejanz)
 - Enh #295: Allowed to use aliases in generator's templates (dmirogin)
 - Enh #300: Removed space from commented out code so when uncommenting in IDEs there's no extra spacing (bscheshirwork)

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -10,6 +10,7 @@ namespace yii\gii\controllers;
 use Yii;
 use yii\web\Controller;
 use yii\web\NotFoundHttpException;
+use yii\web\Response;
 
 /**
  * @author Qiang Xue <qiang.xue@gmail.com>
@@ -26,6 +27,13 @@ class DefaultController extends Controller
      * @var \yii\gii\Generator
      */
     public $generator;
+    
+    
+    public function beforeAction($action)
+    {
+        Yii::$app->response->format = Response::FORMAT_HTML;
+        return parent::beforeAction($action);
+    }
 
 
     public function actionIndex()

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -28,7 +28,9 @@ class DefaultController extends Controller
      */
     public $generator;
     
-    
+    /**
+     * @inheritdoc
+     */
     public function beforeAction($action)
     {
         Yii::$app->response->format = Response::FORMAT_HTML;


### PR DESCRIPTION
For times when developing a REST app and we want to access gii module from browser, the problem at this time is that the response format will be  yii\web\Response::FORMAT_JSON

| Q             | A
| ------------- | ---
| Is bugfix?   | yes
| New feature?  |no
| Breaks BC?    |no
| Tests pass?   |?
