### PR TITLE
crud actions - add @throws tags for 404 exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Yii Framework 2 gii extension Change Log
 
 2.0.6 under development
 -----------------------
+- Enh #319: Added @throws tags for 404 exceptions in CRUD actions (and800)
 - Bug #317: Force HTML content type in response to display HTML when app is configured for REST API (microThread)
 - Enh #315: Make `yii\gii\generators\model\Generator` `generateProperties` protected (claudejanz)
 - Enh #295: Allowed to use aliases in generator's templates (dmirogin)

--- a/generators/crud/default/controller.php
+++ b/generators/crud/default/controller.php
@@ -89,6 +89,7 @@ class <?= $controllerClass ?> extends <?= StringHelper::basename($generator->bas
      * Displays a single <?= $modelClass ?> model.
      * <?= implode("\n     * ", $actionParamComments) . "\n" ?>
      * @return mixed
+     * @throws NotFoundHttpException if the model cannot be found
      */
     public function actionView(<?= $actionParams ?>)
     {
@@ -120,6 +121,7 @@ class <?= $controllerClass ?> extends <?= StringHelper::basename($generator->bas
      * If update is successful, the browser will be redirected to the 'view' page.
      * <?= implode("\n     * ", $actionParamComments) . "\n" ?>
      * @return mixed
+     * @throws NotFoundHttpException if the model cannot be found
      */
     public function actionUpdate(<?= $actionParams ?>)
     {
@@ -139,6 +141,7 @@ class <?= $controllerClass ?> extends <?= StringHelper::basename($generator->bas
      * If deletion is successful, the browser will be redirected to the 'index' page.
      * <?= implode("\n     * ", $actionParamComments) . "\n" ?>
      * @return mixed
+     * @throws NotFoundHttpException if the model cannot be found
      */
     public function actionDelete(<?= $actionParams ?>)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

describe exceptions which are thrown by `findModel()` - because my recently updated phpstorm has started to highlight absence of them as an error 🤔