### PR TITLE
Fix bug in CRUD update view generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.7 under development
 -----------------------
 
-- no changes in this release.
+- Bug #328: Fix bug in CRUD update view generator (ricpelo)
 
 
 2.0.6 December 23, 2017

--- a/generators/crud/default/views/update.php
+++ b/generators/crud/default/views/update.php
@@ -19,7 +19,7 @@ use yii\helpers\Html;
 $this->title = <?= strtr($generator->generateString('Update ' .
     Inflector::camel2words(StringHelper::basename($generator->modelClass)) .
     ': {nameAttribute}', ['nameAttribute' => '{nameAttribute}']), [
-    '\'{nameAttribute}\'' => '$model->' . $generator->getNameAttribute()
+    '{nameAttribute}\'' => '\' . $model->' . $generator->getNameAttribute()
 ]) ?>;
 $this->params['breadcrumbs'][] = ['label' => <?= $generator->generateString(Inflector::pluralize(Inflector::camel2words(StringHelper::basename($generator->modelClass)))) ?>, 'url' => ['index']];
 $this->params['breadcrumbs'][] = ['label' => $model-><?= $generator->getNameAttribute() ?>, 'url' => ['view', <?= $urlParams ?>]];


### PR DESCRIPTION
`{nameAttribute}` substring no longer shows.

Fixes yiisoft/yii2-gii#328

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #328
