### PR TITLE
Fixed incorrect validation rule for TINYINT column type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.7 under development
 -----------------------
 
+- Bug #333: Fixed incorrect validation rule for TINYINT column type (nostop8)
 - Bug #328: Fix bug in CRUD update view generator (ricpelo)
 
 

--- a/generators/model/Generator.php
+++ b/generators/model/Generator.php
@@ -315,6 +315,7 @@ class Generator extends \yii\gii\Generator
                 case Schema::TYPE_SMALLINT:
                 case Schema::TYPE_INTEGER:
                 case Schema::TYPE_BIGINT:
+                case Schema::TYPE_TINYINT:
                     $types['integer'][] = $column->name;
                     break;
                 case Schema::TYPE_BOOLEAN:


### PR DESCRIPTION
After recent updates to Yii2 Schema, Gii Model started to generate `string` validator rules for `tinyint` column type, where instead it should be `integer` validator as it always was. After these updates my applications started to show validation errors (particularly REST applications, did not test with client-server application).

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | #333 
