### PR TITLE
fix #185 - Error when invalid FKs referencing non-existent table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 gii extension Change Log
 - Bug #333: Fixed incorrect validation rule for TINYINT column type (nostop8)
 - Bug #328: Fix bug in CRUD update view generator (ricpelo)
 - Bug #340: Fix bug in CRUD SearchModel generator (JeanWolf)
+- Bug #185: Fix bug in Model generators when FKs pointing to non-existing tables (adipriyantobpn)
 
 
 2.0.6 December 23, 2017

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -562,6 +562,10 @@ class Generator extends \yii\gii\Generator
                 foreach ($table->foreignKeys as $refs) {
                     $refTable = $refs[0];
                     $refTableSchema = $db->getTableSchema($refTable);
+                    if ($refTableSchema === null) {
+                        // Foreign key could point to non-existing table: https://github.com/yiisoft/yii2-gii/issues/34
+                        continue;
+                    }
                     unset($refs[0]);
                     $fks = array_keys($refs);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | #185 

Do same steps done by @samdark at commit aeec43d, but this time in addInverseRelations() function