### PR TITLE
Fixed Model Generator to support abstract baseClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.0.8 under development
 -----------------------
 
-- no changes in this release.
+- Bug #327: Fixed bug in Model generator when $baseClass is an abstract class (rhertogh)
 
 
 2.0.7 May 3, 2018

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -692,10 +692,6 @@ class Generator extends \yii\gii\Generator
             $baseClass = $this->baseClass;
             $baseClassReflector = new \ReflectionClass($baseClass);
             if ($baseClassReflector->isAbstract()) {
-                //Extra check for security to validate that $baseClass is indeed a class since this variable is used in eval
-                if (!class_exists($baseClass)) {
-                    throw new InvalidConfigException("Class '$class' does not exist or has syntax error.");
-                }
                 $baseClassWrapper =
                     'namespace ' . __NAMESPACE__ . ';'.
                     'class GiiBaseClassWrapper extends \\' . $baseClass . ' {' .

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -8,6 +8,7 @@
 namespace yii\gii\generators\model;
 
 use Yii;
+use yii\base\InvalidConfigException;
 use yii\db\ActiveQuery;
 use yii\db\ActiveRecord;
 use yii\db\Connection;
@@ -689,9 +690,27 @@ class Generator extends \yii\gii\Generator
         /* @var $baseModel \yii\db\ActiveRecord */
         if ($baseModel === null) {
             $baseClass = $this->baseClass;
-            $baseModel = new $baseClass();
+            $baseClassReflector = new \ReflectionClass($baseClass);
+            if ($baseClassReflector->isAbstract()) {
+                //Extra check for security to validate that $baseClass is indeed a class since this variable is used in eval
+                if (!class_exists($baseClass)) {
+                    throw new InvalidConfigException("Class '$class' does not exist or has syntax error.");
+                }
+                $baseClassWrapper =
+                    'namespace ' . __NAMESPACE__ . ';'.
+                    'class GiiBaseClassWrapper extends \\' . $baseClass . ' {' .
+                        'public static function tableName(){' .
+                            'return "' . addslashes($table->fullName) . '";' .
+                        '}' .
+                    '};' .
+                    'return new GiiBaseClassWrapper();';
+                $baseModel = eval($baseClassWrapper);
+            } else {
+                $baseModel = new $baseClass();
+            }
             $baseModel->setAttributes([]);
         }
+
         if (!empty($key) && strcasecmp($key, 'id')) {
             if (substr_compare($key, 'id', -2, 2, true) === 0) {
                 $key = rtrim(substr($key, 0, -2), '_');


### PR DESCRIPTION
Checks if baseClass is an abstract class, and if so wrap it in a regular class before instantiating it.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #327 "Cannot instantiate abstract class common\models\AbstractActiveRecord"
