### PR TITLE
Force call find method in static instead of itself

### DIFF
--- a/src/generators/crud/default/search.php
+++ b/src/generators/crud/default/search.php
@@ -63,7 +63,7 @@ class <?= $searchModelClass ?> extends <?= isset($modelAlias) ? $modelAlias : $m
      */
     public function search($params)
     {
-        $query = <?= isset($modelAlias) ? $modelAlias : $modelClass ?>::find();
+        $query = static::find();
 
         // add conditions that should always apply here
 


### PR DESCRIPTION
Makes it possible refer itself in inherited class.
In the grid, you can receive the search class generated in the $model parameter
Call itself find method, if exist
It possible create fields in itself and auto fill in find()

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
