### PR TITLE
remove hard coded Id field

### DIFF
--- a/src/generators/crud/Generator.php
+++ b/src/generators/crud/Generator.php
@@ -503,7 +503,7 @@ class Generator extends \yii\gii\Generator
         $class = $this->modelClass;
         $pks = $class::primaryKey();
         if (count($pks) === 1) {
-            return '$id';
+            return '$' . $pks[0];
         }
 
         return '$' . implode(', $', $pks);


### PR DESCRIPTION
hard coded $id field could be $_id for mongodb, changed code to use the actual PK

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
