### PR TITLE
Made yii\gii\CodeFile indepdendent of controller context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 gii extension Change Log
 -----------------------
 
 - Enh #390, Bug #260: Create (bootstrap)-independent version (simialbi)
+- Enh: Made `yii\gii\CodeFile` indepdendent of controller context, do not apply `$newDirMode` and `$newFileMode` if module is not available (CeBe)
 
 
 2.0.8 December 08, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 gii extension Change Log
 -----------------------
 
 - Enh #390, Bug #260: Create (bootstrap)-independent version (simialbi)
-- Enh: Made `yii\gii\CodeFile` indepdendent of controller context, do not apply `$newDirMode` and `$newFileMode` if module is not available (CeBe)
+- Enh #395: Made `yii\gii\CodeFile` indepdendent of controller context, do not apply `$newDirMode` and `$newFileMode` if module is not available (CeBe)
 
 
 2.0.8 December 08, 2018

--- a/src/CodeFile.php
+++ b/src/CodeFile.php
@@ -81,13 +81,17 @@ class CodeFile extends BaseObject
      */
     public function save()
     {
-        $module = Yii::$app->controller->module;
+        $module = isset(Yii::$app->controller) ? Yii::$app->controller->module : null;
         if ($this->operation === self::OP_CREATE) {
             $dir = dirname($this->path);
             if (!is_dir($dir)) {
-                $mask = @umask(0);
-                $result = @mkdir($dir, $module->newDirMode, true);
-                @umask($mask);
+                if ($module instanceof \yii\gii\Module) {
+                    $mask = @umask(0);
+                    $result = @mkdir($dir, $module->newDirMode, true);
+                    @umask($mask);
+                } else {
+                    $result = @mkdir($dir, 0777, true);
+                }
                 if (!$result) {
                     return "Unable to create the directory '$dir'.";
                 }
@@ -97,9 +101,11 @@ class CodeFile extends BaseObject
             return "Unable to write the file '{$this->path}'.";
         }
 
-        $mask = @umask(0);
-        @chmod($this->path, $module->newFileMode);
-        @umask($mask);
+        if ($module instanceof \yii\gii\Module) {
+            $mask = @umask(0);
+            @chmod($this->path, $module->newFileMode);
+            @umask($mask);
+        }
 
         return true;
     }


### PR DESCRIPTION
do not apply `$newDirMode` and `$newFileMode` if module is not available.

Code uses default umask in that case.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | n/a
