### PR TITLE
improved generation annotation of properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.1.3 under development
 -----------------------
 
-- no changes in this release.
+- Improved generation of model attributes Phpdoc annotations types  
 
 
 2.1.2 October 08, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.1.3 under development
 -----------------------
 
-- Improved generation of model attributes Phpdoc annotations types  
+- Enh #416: Improved generation of model attributes and type annotations (uldisn)
 
 
 2.1.2 October 08, 2019

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -7,7 +7,6 @@
 
 namespace yii\gii\generators\model;
 
-use ReflectionClass;
 use Yii;
 use yii\base\NotSupportedException;
 use yii\db\ActiveQuery;
@@ -255,7 +254,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates the properties for the specified table.
-     * @param TableSchema $table the table schema
+     * @param \yii\db\TableSchema $table the table schema
      * @return array the generated properties (property => type)
      * @since 2.0.6
      */
@@ -304,7 +303,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates the attribute labels for the specified table.
-     * @param TableSchema $table the table schema
+     * @param \yii\db\TableSchema $table the table schema
      * @return array the generated attribute labels (name => label)
      */
     public function generateLabels($table)
@@ -329,7 +328,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates validation rules for the specified table.
-     * @param TableSchema $table the table schema
+     * @param \yii\db\TableSchema $table the table schema
      * @return array the generated validation rules
      */
     public function generateRules($table)
@@ -433,7 +432,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates relations using a junction table by adding an extra viaTable().
-     * @param TableSchema the table being checked
+     * @param \yii\db\TableSchema the table being checked
      * @param array $fks obtained from the checkJunctionTable() method
      * @param array $relations
      * @return array modified $relations
@@ -666,7 +665,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Checks if the given table is a junction table, that is it has at least one pair of unique foreign keys.
-     * @param TableSchema the table being checked
+     * @param \yii\db\TableSchema the table being checked
      * @return array|bool all unique foreign key pairs if the table is a junction table,
      * or false if the table is not a junction table.
      */
@@ -710,7 +709,7 @@ class Generator extends \yii\gii\Generator
     /**
      * Generate a relation name for the specified table and a base name.
      * @param array $relations the relations being generated currently.
-     * @param TableSchema $table the table schema
+     * @param \yii\db\TableSchema $table the table schema
      * @param string $key a base name that the relation name may be generated from
      * @param bool $multiple whether this is a has-many relation
      * @return string the relation name
@@ -718,10 +717,10 @@ class Generator extends \yii\gii\Generator
     protected function generateRelationName($relations, $table, $key, $multiple)
     {
         static $baseModel;
-        /* @var $baseModel ActiveRecord */
+        /* @var $baseModel \yii\db\ActiveRecord */
         if ($baseModel === null) {
             $baseClass = $this->baseClass;
-            $baseClassReflector = new ReflectionClass($baseClass);
+            $baseClassReflector = new \ReflectionClass($baseClass);
             if ($baseClassReflector->isAbstract()) {
                 $baseClassWrapper =
                     'namespace ' . __NAMESPACE__ . ';'.
@@ -972,12 +971,12 @@ class Generator extends \yii\gii\Generator
     {
         /** @var Connection $db */
         $db = $this->getDbConnection();
-        return $db instanceof Connection ? $db->driverName : null;
+        return $db instanceof \yii\db\Connection ? $db->driverName : null;
     }
 
     /**
      * Checks if any of the specified columns is auto incremental.
-     * @param TableSchema $table the table schema
+     * @param \yii\db\TableSchema $table the table schema
      * @param array $columns columns to check for autoIncrement property
      * @return bool whether any of the specified columns is auto incremental.
      */

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -288,7 +288,7 @@ class Generator extends \yii\gii\Generator
                 default:
                     $type = $column->phpType;
             }
-            if($column->allowNull){
+            if ($column->allowNull){
                 $type .= '|null';
             }
             $properties[$column->name] = [

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -305,4 +305,82 @@ class ModelGeneratorTest extends GiiTestCase
             $this->assertEquals($expectedClassName, $generatedClassName);
         }
     }
+
+    /**
+     * @return array
+     */
+    public function tablePropertiesProvider()
+    {
+        return [
+            [
+                'tableName' => 'category_photo',
+                'columns' => [
+                    [
+                        'columnName' => 'id',
+                        'propertyRow' => '* @property int $id',
+                    ],
+                    [
+                        'columnName' => 'category_id',
+                        'propertyRow' => '* @property int $category_id',
+                    ],
+                    [
+                        'columnName' => 'display_number',
+                        'propertyRow' => '* @property int $display_number',
+                    ],
+
+                ]
+            ],
+            [
+                'tableName' => 'product',
+                'columns' => [
+                    [
+                        'columnName' => 'id',
+                        'propertyRow' => '* @property int $id',
+                    ],
+                    [
+                        'columnName' => 'category_id',
+                        'propertyRow' => '* @property int $supplier_id',
+                    ],
+                    [
+                        'columnName' => 'category_language_code',
+                        'propertyRow' => '* @property string $category_language_code',
+                    ],
+                    [
+                        'columnName' => 'category_id',
+                        'propertyRow' => '* @property int $category_id',
+                    ],
+                    [
+                        'columnName' => 'internal_name',
+                        'propertyRow' => '* @property string|null $internal_name',
+                    ],
+
+                ]
+            ],
+        ];
+
+    }
+
+    /**
+     * @dataProvider tablePropertiesProvider
+     *
+     * @param $tableName string
+     * @param $columns
+     */
+    public function testGenerateProperties($tableName, $columns){
+        $generator = new ModelGenerator();
+        $generator->template = 'default';
+        $generator->tableName = $tableName;
+
+        $files = $generator->generate();
+
+        $code = $files[0]->content;
+        foreach ($columns as $column) {
+            $location = strpos($code, $column['propertyRow']);
+            $this->assertTrue(
+                $location !== false,
+                "Column \"{$column['columnName']}\" properties should be there:\n" . $column['propertyRow']
+            );
+        }
+
+    }
 }

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -363,10 +363,11 @@ class ModelGeneratorTest extends GiiTestCase
     /**
      * @dataProvider tablePropertiesProvider
      *
-     * @param $tableName string
-     * @param $columns
+     * @param string $tableName
+     * @param array $columns
      */
-    public function testGenerateProperties($tableName, $columns){
+    public function testGenerateProperties($tableName, $columns)
+    {
         $generator = new ModelGenerator();
         $generator->template = 'default';
         $generator->tableName = $tableName;


### PR DESCRIPTION
Signed-off-by: uldisn <uldisnelsons@gmail.com>

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

New features
--------------
1. added type float (MySql: decimal, float, money, double)

2. If column value can be null, property type for example for string column set like this
```php
/**
 * @property string|null $car_number
 */
```

Bug
-----

For MySql table
```mysql
CREATE TABLE `csc_car_unload` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `task_id` smallint(5) unsigned NOT NULL,
  `delivery_id` int(10) unsigned NOT NULL,
  PRIMARY KEY (`id`),
  KEY `task_id` (`task_id`),
  KEY `delivery_id` (`delivery_id`),
  CONSTRAINT `csc_car_unload_ibfk_1` FOREIGN KEY (`task_id`) REFERENCES `csc_task` (`id`),
  CONSTRAINT `csc_car_unload_ibfk_2` FOREIGN KEY (`delivery_id`) REFERENCES `cmd_delivery` (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=5948 DEFAULT CHARSET=latin1
```
Properties $id and $delivery_id type is generated as string, but must be integer

```php
/**
 * This is the base-model class for table "csc_car_unload".
 *
 * @property string $id
 * @property integer $task_id
 * @property string $delivery_id
 *
 * @property \coalmar\screen\models\CscTask $task
 * @property \coalmar\screen\models\CmdDelivery $delivery
 */
```


