### PR TITLE
bugfix: fixed issue where RTL implementation for foreign keys (e.g. c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ Yii Framework 2 gii extension Change Log
 2.1.2 October 08, 2019
 ----------------------
 
-- Bug #417: Fixed issue where RTL implementation for foreign keys causes problems with LTR tables names
+- Bug #417: Fixed issue where RTL implementation for foreign keys causes problems with LTR tables names (NickvdMeij)
 - Bug #413: Controller Generator produces invalid alias when namespace starts with backslash (cebe)
+
 
 2.1.1 August 13, 2019
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Yii Framework 2 gii extension Change Log
 2.1.2 October 08, 2019
 ----------------------
 
+- Bug #417: Fixed issue where RTL implementation for foreign keys causes problems with LTR tables names
 - Bug #413: Controller Generator produces invalid alias when namespace starts with backslash (cebe)
-
 
 2.1.1 August 13, 2019
 ---------------------

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -719,8 +719,8 @@ class Generator extends \yii\gii\Generator
         if (!empty($key) && strcasecmp($key, 'id')) {
             if (substr_compare($key, 'id', -2, 2, true) === 0) {
                 $key = rtrim(substr($key, 0, -2), '_');
-            } elseif (substr_compare($key, 'id', 0, 2, true) === 0) {
-                $key = ltrim(substr($key, 2, strlen($key)), '_');
+            } elseif (substr_compare($key, 'id_', 0, 3, true) === 0) {
+                $key = ltrim(substr($key, 3, strlen($key)), '_');
             }
         }
         if ($multiple) {

--- a/tests/data/sqlite.sql
+++ b/tests/data/sqlite.sql
@@ -87,14 +87,14 @@ CREATE TABLE "product_language" (
 
 CREATE TABLE "organization" (
   id INTEGER NOT NULL,
-  name varchar(255) NOT NULL
+  name varchar(255) NOT NULL,
   PRIMARY KEY (id)
 );
 
 CREATE TABLE "identity_provider" (
   id INTEGER NOT NULL,
   organization_id INTEGER NOT NULL,
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
   CONSTRAINT idp_oid_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES "organization" (id) ON DELETE CASCADE
 );
 
@@ -107,8 +107,8 @@ CREATE TABLE "user_rtl" (
 CREATE TABLE "blog_rtl" (
   id INTEGER NOT NULL,
   id_user INTEGER NOT NULL,
-  name varchar(255) NOT NULL
-  PRIMARY KEY (id)
+  name varchar(255) NOT NULL,
+  PRIMARY KEY (id),
   CONSTRAINT blog_rtl_id_user_rtl_id_fkey FOREIGN KEY (id_user) REFERENCES "rtl_user" (id) ON DELETE CASCADE
 );
 

--- a/tests/data/sqlite.sql
+++ b/tests/data/sqlite.sql
@@ -11,11 +11,11 @@ DROP TABLE IF EXISTS "category";
 DROP TABLE IF EXISTS "customer";
 DROP TABLE IF EXISTS "profile";
 
-DROP TABLE IF EXISTS "organization"
-DROP TABLE IF EXISTS "identity_provider"
+DROP TABLE IF EXISTS "organization";
+DROP TABLE IF EXISTS "identity_provider";
 
-DROP TABLE IF EXISTS "user_rtl"
-DROP TABLE IF EXISTS "blog_rtl"
+DROP TABLE IF EXISTS "user_rtl";
+DROP TABLE IF EXISTS "blog_rtl";
 
 CREATE TABLE "profile" (
   id INTEGER NOT NULL,

--- a/tests/data/sqlite.sql
+++ b/tests/data/sqlite.sql
@@ -100,7 +100,7 @@ CREATE TABLE "identity_provider" (
 
 CREATE TABLE "user_rtl" (
   id INTEGER NOT NULL,
-  description varchar(128) NOT NULL,
+  name varchar(128) NOT NULL,
   PRIMARY KEY (id)
 );
 
@@ -109,7 +109,7 @@ CREATE TABLE "blog_rtl" (
   id_user INTEGER NOT NULL,
   name varchar(255) NOT NULL,
   PRIMARY KEY (id),
-  CONSTRAINT blog_rtl_id_user_rtl_id_fkey FOREIGN KEY (id_user) REFERENCES "rtl_user" (id) ON DELETE CASCADE
+  CONSTRAINT blog_rtl_id_user_rtl_id_fkey FOREIGN KEY (id_user) REFERENCES "user_rtl" (id) ON DELETE CASCADE
 );
 
 

--- a/tests/data/sqlite.sql
+++ b/tests/data/sqlite.sql
@@ -11,6 +11,12 @@ DROP TABLE IF EXISTS "category";
 DROP TABLE IF EXISTS "customer";
 DROP TABLE IF EXISTS "profile";
 
+DROP TABLE IF EXISTS "organization"
+DROP TABLE IF EXISTS "identity_provider"
+
+DROP TABLE IF EXISTS "user_rtl"
+DROP TABLE IF EXISTS "blog_rtl"
+
 CREATE TABLE "profile" (
   id INTEGER NOT NULL,
   description varchar(128) NOT NULL,
@@ -78,6 +84,34 @@ CREATE TABLE "product_language" (
   UNIQUE (supplier_id),
   CONSTRAINT product_language_id_supplier_id_fkey FOREIGN KEY (supplier_id, id) REFERENCES "product" (supplier_id, id) ON DELETE CASCADE
 );
+
+CREATE TABLE "organization" (
+  id INTEGER NOT NULL,
+  name varchar(255) NOT NULL
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE "identity_provider" (
+  id INTEGER NOT NULL,
+  organization_id INTEGER NOT NULL,
+  PRIMARY KEY (id)
+  CONSTRAINT idp_oid_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES "organization" (id) ON DELETE CASCADE
+);
+
+CREATE TABLE "user_rtl" (
+  id INTEGER NOT NULL,
+  description varchar(128) NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE "blog_rtl" (
+  id INTEGER NOT NULL,
+  id_user INTEGER NOT NULL,
+  name varchar(255) NOT NULL
+  PRIMARY KEY (id)
+  CONSTRAINT blog_rtl_id_user_rtl_id_fkey FOREIGN KEY (id_user) REFERENCES "rtl_user" (id) ON DELETE CASCADE
+);
+
 
 INSERT INTO "profile" (description) VALUES ('profile customer 1');
 INSERT INTO "profile" (description) VALUES ('profile customer 3');

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -122,6 +122,35 @@ class ModelGeneratorTest extends GiiTestCase
                     'expected' => true,
                 ],
             ]],
+
+            ['organization', 'Organization.php', [
+                [
+                    'name' => 'function getIdentityProviders()',
+                    'relation' => "\$this->hasMany(IdentityProvider::className(), ['organization_id' => 'id'])->inverseOf('organization');",
+                    'expected' => true,
+                ],
+            ]],
+            ['identity_provider', 'ProductLanguage.php', [
+                [
+                    'name' => 'function getOrganization()',
+                    'relation' => "\$this->hasOne(Organization::className(), ['id' => 'organization_id'])->inverseOf('identityProviders');",
+                    'expected' => true,
+                ],
+            ]],
+            ['user_rtl', 'UserRtl.php', [
+                [
+                    'name' => 'function getBlogRtls()',
+                    'relation' => "\$this->hasMany(BlogRtl::className(), ['id' => 'id_user'])->inverseOf('userRtl');",
+                    'expected' => true,
+                ],
+            ]],
+            ['blog_rtl', 'BlogRtl.php', [
+                [
+                    'name' => 'function getUserRtls()',
+                    'relation' => "\$this->hasOne(UserRtl::className(), ['id_user' => 'id'])->inverseOf('blogRtls');",
+                    'expected' => true,
+                ],
+            ]],
         ];
     }
 
@@ -158,10 +187,6 @@ class ModelGeneratorTest extends GiiTestCase
                 . ($relation['expected'] ? '' : ' not')." be there:\n" . $code
             );
         }
-    }
-
-    public function testSchemas()
-    {
     }
 
     /**

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -150,7 +150,7 @@ class ModelGeneratorTest extends GiiTestCase
             ]],
             ['blog_rtl', 'BlogRtl.php', [
                 [
-                    'name' => 'function getUserRtls()',
+                    'name' => 'function getUser()',
                     'relation' => "\$this->hasOne(UserRtl::className(), ['id' => 'id_user']);",
                     'expected' => true,
                 ],

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -28,16 +28,20 @@ class ModelGeneratorTest extends GiiTestCase
         $this->assertTrue($valid, 'Validation failed: ' . print_r($generator->getErrors(), true));
 
         $files = $generator->generate();
-        $this->assertEquals(8, count($files));
+        $this->assertEquals(12, count($files));
         $expectedNames = [
             'Attribute.php',
+            'BlogRtl.php',
             'Category.php',
             'CategoryPhoto.php',
             'Customer.php',
+            'IdentityProvider.php',
+            'Organization.php',
             'Product.php',
             'ProductLanguage.php',
             'Profile.php',
             'Supplier.php',
+            'UserRtl.php',
         ];
         $fileNames = array_map(function ($f) {
             return basename($f->path);
@@ -140,14 +144,14 @@ class ModelGeneratorTest extends GiiTestCase
             ['user_rtl', 'UserRtl.php', [
                 [
                     'name' => 'function getBlogRtls()',
-                    'relation' => "\$this->hasMany(BlogRtl::className(), ['id' => 'id_user']);",
+                    'relation' => "\$this->hasMany(BlogRtl::className(), ['id_user' => 'id']);",
                     'expected' => true,
                 ],
             ]],
             ['blog_rtl', 'BlogRtl.php', [
                 [
                     'name' => 'function getUserRtls()',
-                    'relation' => "\$this->hasOne(UserRtl::className(), ['id_user' => 'id']);",
+                    'relation' => "\$this->hasOne(UserRtl::className(), ['id' => 'id_user']);",
                     'expected' => true,
                 ],
             ]],

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -130,7 +130,7 @@ class ModelGeneratorTest extends GiiTestCase
                     'expected' => true,
                 ],
             ]],
-            ['identity_provider', 'ProductLanguage.php', [
+            ['identity_provider', 'IdentityProvider.php', [
                 [
                     'name' => 'function getOrganization()',
                     'relation' => "\$this->hasOne(Organization::className(), ['id' => 'organization_id']);",

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -126,28 +126,28 @@ class ModelGeneratorTest extends GiiTestCase
             ['organization', 'Organization.php', [
                 [
                     'name' => 'function getIdentityProviders()',
-                    'relation' => "\$this->hasMany(IdentityProvider::className(), ['organization_id' => 'id'])->inverseOf('organization');",
+                    'relation' => "\$this->hasMany(IdentityProvider::className(), ['organization_id' => 'id']);",
                     'expected' => true,
                 ],
             ]],
             ['identity_provider', 'ProductLanguage.php', [
                 [
                     'name' => 'function getOrganization()',
-                    'relation' => "\$this->hasOne(Organization::className(), ['id' => 'organization_id'])->inverseOf('identityProviders');",
+                    'relation' => "\$this->hasOne(Organization::className(), ['id' => 'organization_id']);",
                     'expected' => true,
                 ],
             ]],
             ['user_rtl', 'UserRtl.php', [
                 [
                     'name' => 'function getBlogRtls()',
-                    'relation' => "\$this->hasMany(BlogRtl::className(), ['id' => 'id_user'])->inverseOf('userRtl');",
+                    'relation' => "\$this->hasMany(BlogRtl::className(), ['id' => 'id_user']);",
                     'expected' => true,
                 ],
             ]],
             ['blog_rtl', 'BlogRtl.php', [
                 [
                     'name' => 'function getUserRtls()',
-                    'relation' => "\$this->hasOne(UserRtl::className(), ['id_user' => 'id'])->inverseOf('blogRtls');",
+                    'relation' => "\$this->hasOne(UserRtl::className(), ['id_user' => 'id']);",
                     'expected' => true,
                 ],
             ]],


### PR DESCRIPTION
bugfix: fixed issue where RTL implementation for foreign keys (e.g. column name `id_user` for a foreign key) causes problems with LTR tables names (e.g. foreign key to `IdentityProvider` table becomes relation function `getEntityProviders`)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
