### PR TITLE
Rules default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.1.3 under development
 -----------------------
 
-- no changes in this release.
+- Improved generation of model attributes Phpdoc annotations types  
 
 
 2.1.2 October 08, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Yii Framework 2 gii extension Change Log
 ========================================
 
-2.1.2 under development
------------------------
+2.1.2 October 08, 2019
+----------------------
 
 - Bug #413: Controller Generator produces invalid alias when namespace starts with backslash (cebe)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Yii Framework 2 gii extension Change Log
 ========================================
 
+2.1.3 under development
+-----------------------
+
+- no changes in this release.
+
+
 2.1.2 October 08, 2019
 ----------------------
 

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -337,20 +337,21 @@ class Generator extends \yii\gii\Generator
         $types = [];
         $lengths = [];
 
-        $rules = [];
         $columnsDefaultNull = [];
         $driverName = $this->getDbDriverName();
         foreach ($table->columns as $column) {
-            if (in_array($driverName, ['mysql','sqlite'], true)) {
+            if (in_array($driverName, ['mysql', 'sqlite'], true)) {
                 if ($column->defaultValue !== null) {
                     $rules[] = "[['" . $column->name . "'], 'default', 'value' => $column->defaultValue]";
-                }elseif($column->allowNull){
+                } elseif ($column->allowNull) {
                     $columnsDefaultNull[] = $column->name;
                 }
             }
         }
 
-        if($columnsDefaultNull){
+        $rules = [];
+
+        if ($columnsDefaultNull) {
             $rules[] = "[['" . implode("', '", $columnsDefaultNull) . "'], 'default', 'value' => null]";
         }
 

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -7,7 +7,6 @@
 
 namespace yii\gii\generators\model;
 
-use ReflectionClass;
 use Yii;
 use yii\base\NotSupportedException;
 use yii\db\ActiveQuery;
@@ -255,7 +254,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates the properties for the specified table.
-     * @param TableSchema $table the table schema
+     * @param \yii\db\TableSchema $table the table schema
      * @return array the generated properties (property => type)
      * @since 2.0.6
      */
@@ -304,7 +303,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates the attribute labels for the specified table.
-     * @param TableSchema $table the table schema
+     * @param \yii\db\TableSchema $table the table schema
      * @return array the generated attribute labels (name => label)
      */
     public function generateLabels($table)
@@ -329,7 +328,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates validation rules for the specified table.
-     * @param TableSchema $table the table schema
+     * @param \yii\db\TableSchema $table the table schema
      * @return array the generated validation rules
      */
     public function generateRules($table)
@@ -433,7 +432,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates relations using a junction table by adding an extra viaTable().
-     * @param TableSchema the table being checked
+     * @param \yii\db\TableSchema the table being checked
      * @param array $fks obtained from the checkJunctionTable() method
      * @param array $relations
      * @return array modified $relations
@@ -666,7 +665,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Checks if the given table is a junction table, that is it has at least one pair of unique foreign keys.
-     * @param TableSchema the table being checked
+     * @param \yii\db\TableSchema the table being checked
      * @return array|bool all unique foreign key pairs if the table is a junction table,
      * or false if the table is not a junction table.
      */
@@ -710,7 +709,7 @@ class Generator extends \yii\gii\Generator
     /**
      * Generate a relation name for the specified table and a base name.
      * @param array $relations the relations being generated currently.
-     * @param TableSchema $table the table schema
+     * @param \yii\db\TableSchema $table the table schema
      * @param string $key a base name that the relation name may be generated from
      * @param bool $multiple whether this is a has-many relation
      * @return string the relation name
@@ -718,10 +717,10 @@ class Generator extends \yii\gii\Generator
     protected function generateRelationName($relations, $table, $key, $multiple)
     {
         static $baseModel;
-        /* @var $baseModel ActiveRecord */
+        /* @var $baseModel \yii\db\ActiveRecord */
         if ($baseModel === null) {
             $baseClass = $this->baseClass;
-            $baseClassReflector = new ReflectionClass($baseClass);
+            $baseClassReflector = new \ReflectionClass($baseClass);
             if ($baseClassReflector->isAbstract()) {
                 $baseClassWrapper =
                     'namespace ' . __NAMESPACE__ . ';'.
@@ -972,12 +971,12 @@ class Generator extends \yii\gii\Generator
     {
         /** @var Connection $db */
         $db = $this->getDbConnection();
-        return $db instanceof Connection ? $db->driverName : null;
+        return $db instanceof \yii\db\Connection ? $db->driverName : null;
     }
 
     /**
      * Checks if any of the specified columns is auto incremental.
-     * @param TableSchema $table the table schema
+     * @param \yii\db\TableSchema $table the table schema
      * @param array $columns columns to check for autoIncrement property
      * @return bool whether any of the specified columns is auto incremental.
      */

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -7,6 +7,7 @@
 
 namespace yii\gii\generators\model;
 
+use ReflectionClass;
 use Yii;
 use yii\base\NotSupportedException;
 use yii\db\ActiveQuery;
@@ -254,7 +255,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates the properties for the specified table.
-     * @param \yii\db\TableSchema $table the table schema
+     * @param TableSchema $table the table schema
      * @return array the generated properties (property => type)
      * @since 2.0.6
      */
@@ -303,7 +304,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates the attribute labels for the specified table.
-     * @param \yii\db\TableSchema $table the table schema
+     * @param TableSchema $table the table schema
      * @return array the generated attribute labels (name => label)
      */
     public function generateLabels($table)
@@ -328,13 +329,31 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates validation rules for the specified table.
-     * @param \yii\db\TableSchema $table the table schema
+     * @param TableSchema $table the table schema
      * @return array the generated validation rules
      */
     public function generateRules($table)
     {
         $types = [];
         $lengths = [];
+
+        $rules = [];
+        $columnsDefaultNull = [];
+        $driverName = $this->getDbDriverName();
+        foreach ($table->columns as $column) {
+            if (in_array($driverName, ['mysql','sqlite'], true)) {
+                if ($column->defaultValue !== null) {
+                    $rules[] = "[['" . $column->name . "'], 'default', 'value' => $column->defaultValue]";
+                }elseif($column->allowNull){
+                    $columnsDefaultNull[] = $column->name;
+                }
+            }
+        }
+
+        if($columnsDefaultNull){
+            $rules[] = "[['" . implode("', '", $columnsDefaultNull) . "'], 'default', 'value' => null]";
+        }
+
         foreach ($table->columns as $column) {
             if ($column->autoIncrement) {
                 continue;
@@ -373,8 +392,6 @@ class Generator extends \yii\gii\Generator
                     }
             }
         }
-        $rules = [];
-        $driverName = $this->getDbDriverName();
         foreach ($types as $type => $columns) {
             if ($driverName === 'pgsql' && $type === 'integer') {
                 $rules[] = "[['" . implode("', '", $columns) . "'], 'default', 'value' => null]";
@@ -432,7 +449,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Generates relations using a junction table by adding an extra viaTable().
-     * @param \yii\db\TableSchema the table being checked
+     * @param TableSchema the table being checked
      * @param array $fks obtained from the checkJunctionTable() method
      * @param array $relations
      * @return array modified $relations
@@ -665,7 +682,7 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Checks if the given table is a junction table, that is it has at least one pair of unique foreign keys.
-     * @param \yii\db\TableSchema the table being checked
+     * @param TableSchema the table being checked
      * @return array|bool all unique foreign key pairs if the table is a junction table,
      * or false if the table is not a junction table.
      */
@@ -709,7 +726,7 @@ class Generator extends \yii\gii\Generator
     /**
      * Generate a relation name for the specified table and a base name.
      * @param array $relations the relations being generated currently.
-     * @param \yii\db\TableSchema $table the table schema
+     * @param TableSchema $table the table schema
      * @param string $key a base name that the relation name may be generated from
      * @param bool $multiple whether this is a has-many relation
      * @return string the relation name
@@ -717,10 +734,10 @@ class Generator extends \yii\gii\Generator
     protected function generateRelationName($relations, $table, $key, $multiple)
     {
         static $baseModel;
-        /* @var $baseModel \yii\db\ActiveRecord */
+        /* @var $baseModel ActiveRecord */
         if ($baseModel === null) {
             $baseClass = $this->baseClass;
-            $baseClassReflector = new \ReflectionClass($baseClass);
+            $baseClassReflector = new ReflectionClass($baseClass);
             if ($baseClassReflector->isAbstract()) {
                 $baseClassWrapper =
                     'namespace ' . __NAMESPACE__ . ';'.
@@ -971,12 +988,12 @@ class Generator extends \yii\gii\Generator
     {
         /** @var Connection $db */
         $db = $this->getDbConnection();
-        return $db instanceof \yii\db\Connection ? $db->driverName : null;
+        return $db instanceof Connection ? $db->driverName : null;
     }
 
     /**
      * Checks if any of the specified columns is auto incremental.
-     * @param \yii\db\TableSchema $table the table schema
+     * @param TableSchema $table the table schema
      * @param array $columns columns to check for autoIncrement property
      * @return bool whether any of the specified columns is auto incremental.
      */

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -288,7 +288,7 @@ class Generator extends \yii\gii\Generator
                 default:
                     $type = $column->phpType;
             }
-            if($column->allowNull){
+            if ($column->allowNull){
                 $type .= '|null';
             }
             $properties[$column->name] = [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,8 +8,8 @@ define('YII_DEBUG', true);
 $_SERVER['SCRIPT_NAME'] = '/' . __DIR__;
 $_SERVER['SCRIPT_FILENAME'] = __FILE__;
 
-require_once(__DIR__ . '/../vendor/autoload.php');
-require_once(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
+require_once( '../../autoload.php');
+require_once( '../yii2/Yii.php');
 
 Yii::setAlias('@yiiunit/gii', __DIR__);
 Yii::setAlias('@yii/gii', dirname(__DIR__) . '/src');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,8 +8,8 @@ define('YII_DEBUG', true);
 $_SERVER['SCRIPT_NAME'] = '/' . __DIR__;
 $_SERVER['SCRIPT_FILENAME'] = __FILE__;
 
-require_once( '../../autoload.php');
-require_once( '../yii2/Yii.php');
+require_once(__DIR__ . '/../vendor/autoload.php');
+require_once(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 
 Yii::setAlias('@yiiunit/gii', __DIR__);
 Yii::setAlias('@yii/gii', dirname(__DIR__) . '/src');

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -305,4 +305,82 @@ class ModelGeneratorTest extends GiiTestCase
             $this->assertEquals($expectedClassName, $generatedClassName);
         }
     }
+
+    /**
+     * @return array
+     */
+    public function tablePropertiesProvider()
+    {
+        return [
+            [
+                'tableName' => 'category_photo',
+                'columns' => [
+                    [
+                        'columnName' => 'id',
+                        'propertyRow' => '* @property int $id',
+                    ],
+                    [
+                        'columnName' => 'category_id',
+                        'propertyRow' => '* @property int $category_id',
+                    ],
+                    [
+                        'columnName' => 'display_number',
+                        'propertyRow' => '* @property int $display_number',
+                    ],
+
+                ]
+            ],
+            [
+                'tableName' => 'product',
+                'columns' => [
+                    [
+                        'columnName' => 'id',
+                        'propertyRow' => '* @property int $id',
+                    ],
+                    [
+                        'columnName' => 'category_id',
+                        'propertyRow' => '* @property int $supplier_id',
+                    ],
+                    [
+                        'columnName' => 'category_language_code',
+                        'propertyRow' => '* @property string $category_language_code',
+                    ],
+                    [
+                        'columnName' => 'category_id',
+                        'propertyRow' => '* @property int $category_id',
+                    ],
+                    [
+                        'columnName' => 'internal_name',
+                        'propertyRow' => '* @property string|null $internal_name',
+                    ],
+
+                ]
+            ],
+        ];
+
+    }
+
+    /**
+     * @dataProvider tablePropertiesProvider
+     *
+     * @param $tableName string
+     * @param $columns
+     */
+    public function testGenerateProperties($tableName, $columns){
+        $generator = new ModelGenerator();
+        $generator->template = 'default';
+        $generator->tableName = $tableName;
+
+        $files = $generator->generate();
+
+        $code = $files[0]->content;
+        foreach ($columns as $column) {
+            $location = strpos($code, $column['propertyRow']);
+            $this->assertTrue(
+                $location !== false,
+                "Column \"{$column['columnName']}\" properties should be there:\n" . $column['propertyRow']
+            );
+        }
+
+    }
 }

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -384,4 +384,53 @@ class ModelGeneratorTest extends GiiTestCase
         }
 
     }
+
+    /**
+     * @return array
+     */
+    public function rulesDefaultValuesProvider()
+    {
+        return [
+            [
+                'tableName' => 'customer',
+                'columns' => [
+                    [
+                        'columnName' => 'name',
+                        'rule' => '[[\'status\'], \'default\', \'value\' => 0]',
+                    ],
+                    [
+                        'columnName' => 'address',
+                        'rule' => '[[\'name\', \'address\', \'profile_id\'], \'default\', \'value\' => null]',
+                    ],
+                ]
+            ],
+        ];
+
+    }
+
+    /**
+     * @dataProvider rulesDefaultValuesProvider
+     *
+     * @param string $tableName
+     * @param array $columns
+     */
+    public function testRulesDefaultValues($tableName, $columns)
+    {
+        $generator = new ModelGenerator();
+        $generator->template = 'default';
+        $generator->tableName = $tableName;
+
+        $files = $generator->generate();
+
+        $code = $files[0]->content;
+        foreach ($columns as $column) {
+            $location = strpos($code, $column['rule']);
+            $this->assertTrue(
+                $location !== false,
+                "Column \"{$column['columnName']}\" rule should be there:\n" . $column['rule']
+            );
+        }
+
+    }
+
 }

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -363,10 +363,11 @@ class ModelGeneratorTest extends GiiTestCase
     /**
      * @dataProvider tablePropertiesProvider
      *
-     * @param $tableName string
-     * @param $columns
+     * @param string $tableName
+     * @param array $columns
      */
-    public function testGenerateProperties($tableName, $columns){
+    public function testGenerateProperties($tableName, $columns)
+    {
         $generator = new ModelGenerator();
         $generator->template = 'default';
         $generator->tableName = $tableName;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

Generate rules for default values. For example:
```php
    /**
     * {@inheritdoc}
     */
    public function rules()
    {
        return [
            [['status'], 'default', 'value' => 0],
            [['name', 'address', 'profile_id'], 'default', 'value' => null],
            [['email'], 'required'],
            [['address'], 'string'],
            [['status', 'profile_id'], 'integer'],
            [['email', 'name'], 'string', 'max' => 128],
        ];
    }
```
