### PR TITLE
Allow objects including anonymous classes on config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.2.1 under development
 -----------------------
 
-- Bug #428: Permit the usage of anonymous generators using dependency injection
+- Bug #428: Permit the usage of anonymous generators using dependency injection (aguevaraIL)
 
 
 2.2.0 March 24, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.2.1 under development
 -----------------------
 
-- no changes in this release.
+- Bug #428: Permit the usage of anonymous generators using dependency injection
 
 
 2.2.0 March 24, 2020

--- a/src/console/GenerateController.php
+++ b/src/console/GenerateController.php
@@ -10,6 +10,8 @@ namespace yii\gii\console;
 use Yii;
 use yii\base\InlineAction;
 use yii\console\Controller;
+use yii\di\Instance;
+use yii\gii\Generator;
 
 /**
  * This is the command line version of Gii - a code generator.
@@ -71,7 +73,7 @@ class GenerateController extends Controller
     {
         parent::init();
         foreach ($this->generators as $id => $config) {
-            $this->generators[$id] = Yii::createObject($config);
+            $this->generators[$id] = Instance::ensure($config, Generator::class);
         }
     }
 

--- a/src/console/GenerateController.php
+++ b/src/console/GenerateController.php
@@ -73,7 +73,10 @@ class GenerateController extends Controller
     {
         parent::init();
         foreach ($this->generators as $id => $config) {
-            $this->generators[$id] = Instance::ensure($config, Generator::class);
+            $this->generators[$id] = Instance::ensure(
+                $config,
+                Generator::className()
+            );
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

Example of what currently is not possible.

```php
    'modules' => [
        'gii' => [
            'class' => yii\gii\Module::class,
            'generators' => [
                'custom' => new class () extends Generator {
                    public function getName() {
                        return 'Custom Generator';
                    }
                    public function generate()
                    {
                       // ...
                    }
                },
            ],
        ],
```

It throws  exception

`Exception 'yii\base\InvalidConfigException' with message 'Unsupported configuration type: object'`

