### PR TITLE
Bugfix: generate model class in web app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 gii extension Change Log
 -----------------------
 
 - Enh #444: Updated reserved keywords in generator (WinterSilence)
-- Bug #439: Replace pseudo generation of model class to AJAX request (WinterSilence)
+- Bug #439: Replace client-side generation of model class name with an AJAX request and a serverside implementation (WinterSilence)
 
 
 2.2.1 May 02, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 gii extension Change Log
 -----------------------
 
 - Enh #444: Updated reserved keywords in generator (WinterSilence)
-- Bug #439: Replace client-side generation of model class name with an AJAX request and a serverside implementation (WinterSilence)
+- Bug #439: Replace client-side generation of model class name with an AJAX request and a serverside implementation to take options into account (WinterSilence)
 
 
 2.2.1 May 02, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.2.2 under development
 -----------------------
 
+- Bug #439: Replace pseudo generation of model class to AJAX request (WinterSilence)
 - Enh #444: Updated reserved keywords in generator (WinterSilence)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Yii Framework 2 gii extension Change Log
 2.2.2 under development
 -----------------------
 
-- Bug #439: Replace pseudo generation of model class to AJAX request (WinterSilence)
 - Enh #444: Updated reserved keywords in generator (WinterSilence)
+- Bug #439: Replace pseudo generation of model class to AJAX request (WinterSilence)
 
 
 2.2.1 May 02, 2020

--- a/src/assets/js/gii.js
+++ b/src/assets/js/gii.js
@@ -215,8 +215,10 @@ yii.gii = (function ($) {
 
             // model generator: translate table name to model class
             $('#model-generator #generator-tablename').on('blur', function () {
-                var tableName = $(this).val();
-                var tablePrefix = $(this).attr('table_prefix') || '';
+                var $this = $(this);
+                var $modelClass = $('#generator-modelclass');
+                var tableName = $this.val();
+                var tablePrefix = $this.data('table-prefix') || '';
                 if (tablePrefix.length) {
                     // if starts with prefix
                     if (tableName.slice(0, tablePrefix.length) === tablePrefix) {
@@ -224,13 +226,20 @@ yii.gii = (function ($) {
                         tableName = tableName.slice(tablePrefix.length);
                     }
                 }
-                if ($('#generator-modelclass').val() === '' && tableName && tableName.indexOf('*') === -1) {
-                    var modelClass = '';
-                    $.each(tableName.split(/\.|\_/), function() {
-                        if(this.length>0)
-                            modelClass+=this.substring(0,1).toUpperCase()+this.substring(1);
+                if ($modelClass.val() === '' && tableName && tableName.indexOf('*') === -1) {
+                    // request to `default/action`(`Generator::actionGenerateClassName()`)
+                    ajaxRequest = $.ajax({
+                        type: 'POST',
+                        cache: false,
+                        url: $this.data('action'),
+                        data: $('#model-generator').serializeArray(),
+                        success: function (response) {
+                            $modelClass.val(response).blur();
+                        },
+                        error: function (XMLHttpRequest, textStatus, errorThrown) {
+                            $modal.find('.modal-body').html('<div class="error">' + XMLHttpRequest.responseText + '</div>');
+                        }
                     });
-                    $('#generator-modelclass').val(modelClass).blur();
                 }
             });
 

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -1046,8 +1046,8 @@ class Generator extends \yii\gii\Generator
 
     /**
      * Action to generate class name.
-     * 
      * @return string
+     * @since 2.2.2
      */
     public function actionGenerateClassName()
     {

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -1045,6 +1045,16 @@ class Generator extends \yii\gii\Generator
     }
 
     /**
+     * Action to generate class name.
+     * 
+     * @return string
+     */
+    public function actionGenerateClassName()
+    {
+        return $this->generateClassName($this->tableName);
+    }
+
+    /**
      * Generates a query class name from the specified model class name.
      * @param string $modelClassName model class name
      * @return string generated class name

--- a/src/generators/model/form.php
+++ b/src/generators/model/form.php
@@ -1,12 +1,18 @@
 <?php
 
 use yii\gii\generators\model\Generator;
+use yii\helpers\Url;
 
 /* @var $this yii\web\View */
 /* @var $form yii\widgets\ActiveForm */
 /* @var $generator yii\gii\generators\model\Generator */
 
-echo $form->field($generator, 'tableName')->textInput(['table_prefix' => $generator->getTablePrefix()]);
+echo $form->field($generator, 'tableName')->textInput([
+    'data' => [
+        'table-prefix' => $generator->getTablePrefix(), 
+        'action' => Url::to(['default/action', 'id' => 'model', 'name' => 'GenerateClassName'])
+    ]
+]);
 echo $form->field($generator, 'modelClass');
 echo $form->field($generator, 'standardizeCapitals')->checkbox();
 echo $form->field($generator, 'singularize')->checkbox();

--- a/src/generators/model/form.php
+++ b/src/generators/model/form.php
@@ -7,6 +7,8 @@ use yii\helpers\Url;
 /* @var $form yii\widgets\ActiveForm */
 /* @var $generator yii\gii\generators\model\Generator */
 
+echo $form->field($generator, 'standardizeCapitals')->checkbox();
+echo $form->field($generator, 'singularize')->checkbox();
 echo $form->field($generator, 'tableName')->textInput([
     'data' => [
         'table-prefix' => $generator->getTablePrefix(), 
@@ -14,8 +16,6 @@ echo $form->field($generator, 'tableName')->textInput([
     ]
 ]);
 echo $form->field($generator, 'modelClass');
-echo $form->field($generator, 'standardizeCapitals')->checkbox();
-echo $form->field($generator, 'singularize')->checkbox();
 echo $form->field($generator, 'ns');
 echo $form->field($generator, 'baseClass');
 echo $form->field($generator, 'db');

--- a/src/generators/model/form.php
+++ b/src/generators/model/form.php
@@ -7,19 +7,20 @@ use yii\helpers\Url;
 /* @var $form yii\widgets\ActiveForm */
 /* @var $generator yii\gii\generators\model\Generator */
 
-echo $form->field($generator, 'standardizeCapitals')->checkbox();
-echo $form->field($generator, 'singularize')->checkbox();
+echo $form->field($generator, 'db');
+echo $form->field($generator, 'useTablePrefix')->checkbox();
+echo $form->field($generator, 'useSchemaName')->checkbox();
 echo $form->field($generator, 'tableName')->textInput([
     'data' => [
         'table-prefix' => $generator->getTablePrefix(), 
         'action' => Url::to(['default/action', 'id' => 'model', 'name' => 'GenerateClassName'])
     ]
 ]);
+echo $form->field($generator, 'standardizeCapitals')->checkbox();
+echo $form->field($generator, 'singularize')->checkbox();
 echo $form->field($generator, 'modelClass');
 echo $form->field($generator, 'ns');
 echo $form->field($generator, 'baseClass');
-echo $form->field($generator, 'db');
-echo $form->field($generator, 'useTablePrefix')->checkbox();
 echo $form->field($generator, 'generateRelations')->dropDownList([
     Generator::RELATIONS_NONE => 'No relations',
     Generator::RELATIONS_ALL => 'All relations',
@@ -37,4 +38,3 @@ echo $form->field($generator, 'queryClass');
 echo $form->field($generator, 'queryBaseClass');
 echo $form->field($generator, 'enableI18N')->checkbox();
 echo $form->field($generator, 'messageCategory');
-echo $form->field($generator, 'useSchemaName')->checkbox();


### PR DESCRIPTION
Replace pseudo generation to request `gii/default/action` > `yii\gii\generators\model\Generator::actionGenerateClassName()`. 
Replace invalid  attribute(custom/user's attributes must have prefix `data-`)  `table_prefix` to `data-table-prefix`.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #439

yii/gii use something like Selenium tests? 
