### PR TITLE
Added support for the `::class` constant in model generator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.2.5 under development
 -----------------------
 
-- Ehn #489: Added support for the `::class` constant in model generator via the `useClassNameResolutionConstant` setting (rhertogh)
+- Ehn #489: Added support for the `::class` constant in model generator via the `useClassConstant` setting (rhertogh)
 
 
 2.2.4 December 30, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 gii extension Change Log
 - Bug #484: Add parent's labels and hints, fix rule for attribute `moduleClass` in module generator (WinterSilence)
 - Bug #486: Update `assets/js/bs4-native.min.js` to latest version (WinterSilence)
 - Bug #488: Fix `ActionColumn::$urlCreator` in index template of CRUD generator (WinterSilence)
+- Ehn #489: Added support for the `::class` constant in model generator via the `useClassNameResolutionConstant` setting (rhertogh)
 
 
 2.2.3 August 09, 2021

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -50,7 +50,7 @@ class Generator extends \yii\gii\Generator
     public $baseClass = 'yii\db\ActiveRecord';
     public $generateRelations = self::RELATIONS_ALL;
     public $generateJunctionRelationMode = self::JUNCTION_RELATION_VIA_TABLE;
-    public $useClassNameResolutionConstant = null;
+    public $useClassConstant = null;
     public $generateRelationsFromCurrentSchema = true;
     public $generateLabelsFromComments = false;
     public $useTablePrefix = false;
@@ -81,8 +81,8 @@ class Generator extends \yii\gii\Generator
     {
         parent::init();
 
-        if ($this->useClassNameResolutionConstant === null) {
-            $this->useClassNameResolutionConstant = version_compare(PHP_VERSION, '5.5') >= 0;
+        if ($this->useClassConstant === null) {
+            $this->useClassConstant = PHP_VERSION_ID >= 50500;
         }
     }
 
@@ -129,7 +129,7 @@ class Generator extends \yii\gii\Generator
             [['generateRelations'], 'in', 'range' => [self::RELATIONS_NONE, self::RELATIONS_ALL, self::RELATIONS_ALL_INVERSE]],
             [['generateJunctionRelationMode'], 'in', 'range' => [self::JUNCTION_RELATION_VIA_TABLE, self::JUNCTION_RELATION_VIA_MODEL]],
             [
-                ['generateLabelsFromComments', 'useTablePrefix', 'useSchemaName', 'generateQuery', 'generateRelationsFromCurrentSchema', 'useClassNameResolutionConstant', 'enableI18N', 'standardizeCapitals', 'singularize'],
+                ['generateLabelsFromComments', 'useTablePrefix', 'useSchemaName', 'generateQuery', 'generateRelationsFromCurrentSchema', 'useClassConstant', 'enableI18N', 'standardizeCapitals', 'singularize'],
                 'boolean'
             ],
             [['messageCategory'], 'validateMessageCategory', 'skipOnEmpty' => false],
@@ -152,7 +152,7 @@ class Generator extends \yii\gii\Generator
             'generateRelations' => 'Generate Relations',
             'generateJunctionRelationMode' => 'Generate Junction Relations As',
             'generateRelationsFromCurrentSchema' => 'Generate Relations from Current Schema',
-            'useClassNameResolutionConstant' => 'Use `::class`',
+            'useClassConstant' => 'Use `::class`',
             'generateLabelsFromComments' => 'Generate Labels from DB Comments',
             'generateQuery' => 'Generate ActiveQuery',
             'queryNs' => 'ActiveQuery Namespace',
@@ -194,7 +194,7 @@ class Generator extends \yii\gii\Generator
                 Make sure you also generate the junction models when using the "Via Model" option.
             ',
             'generateRelationsFromCurrentSchema' => 'This indicates whether the generator should generate relations from current schema or from all available schemas.',
-            'useClassNameResolutionConstant' => 'Use the `::class` constant instead of the `::className()` method.',
+            'useClassConstant' => 'Use the `::class` constant instead of the `::className()` method.',
             'generateLabelsFromComments' => 'This indicates whether the generator should generate attribute labels
                 by using the comments of the corresponding DB columns.',
             'useTablePrefix' => 'This indicates whether the table name returned by the generated ActiveRecord class
@@ -260,7 +260,7 @@ class Generator extends \yii\gii\Generator
                 'queryBaseClass',
                 'useTablePrefix',
                 'generateQuery',
-                'useClassNameResolutionConstant',
+                'useClassConstant',
             ]
         );
     }
@@ -1169,15 +1169,11 @@ class Generator extends \yii\gii\Generator
      * Returns the class name resolution
      * @param string $class
      * @return string
-     * @see $useClassNameResolutionConstant
+     * @see $useClassConstant
      * @since 2.2.5
      */
     protected function generateClassNameResolution($class)
     {
-        if ($this->useClassNameResolutionConstant) {
-            return $class . '::class';
-        }
-
-        return $class . '::className()';
+        return $class . '::class' . ($this->useClassConstant ? '' : 'Name()');
     }
 }

--- a/src/generators/model/form.php
+++ b/src/generators/model/form.php
@@ -32,6 +32,7 @@ echo $form->field($generator, 'generateJunctionRelationMode')->dropDownList([
     Generator::JUNCTION_RELATION_VIA_MODEL => 'Via Model',
 ]);
 echo $form->field($generator, 'generateRelationsFromCurrentSchema')->checkbox();
+echo $form->field($generator, 'useClassNameResolutionConstant')->checkbox();
 echo $form->field($generator, 'generateLabelsFromComments')->checkbox();
 echo $form->field($generator, 'generateQuery')->checkbox();
 echo $form->field($generator, 'queryNs');

--- a/src/generators/model/form.php
+++ b/src/generators/model/form.php
@@ -32,7 +32,7 @@ echo $form->field($generator, 'generateJunctionRelationMode')->dropDownList([
     Generator::JUNCTION_RELATION_VIA_MODEL => 'Via Model',
 ]);
 echo $form->field($generator, 'generateRelationsFromCurrentSchema')->checkbox();
-echo $form->field($generator, 'useClassNameResolutionConstant')->checkbox();
+echo $form->field($generator, 'useClassConstant')->checkbox();
 echo $form->field($generator, 'generateLabelsFromComments')->checkbox();
 echo $form->field($generator, 'generateQuery')->checkbox();
 echo $form->field($generator, 'queryNs');

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -35,7 +35,7 @@ class SchemaTest extends GiiTestCase
     public function relationsProvider()
     {
         return [
-            // useClassNameResolutionConstant = false
+            // useClassConstant = false
             ['default', 'schema1.*', 5, false, [
                 0 => [ // relations from junction1 table
                     "\$this->hasOne(Schema1Table1::className(), ['id' => 'table1_id']);",
@@ -85,7 +85,7 @@ class SchemaTest extends GiiTestCase
                 ],
             ]],
 
-            // useClassNameResolutionConstant = true
+            // useClassConstant = true
             ['default', 'schema1.*', 5, true, [
                 0 => [ // relations from junction1 table
                     "\$this->hasOne(Schema1Table1::class, ['id' => 'table1_id']);",
@@ -140,26 +140,26 @@ class SchemaTest extends GiiTestCase
     /**
      * @dataProvider relationsProvider
      */
-    public function testViaTableRelationsGenerator($template, $tableName, $filesCount, $classNameResolution, $relationSets)
+    public function testViaTableRelationsGenerator($template, $tableName, $filesCount, $useClassConstant, $relationSets)
     {
-        $this->relationsGeneratorTest($template, $tableName, $filesCount, $classNameResolution, $relationSets, ModelGenerator::JUNCTION_RELATION_VIA_TABLE);
+        $this->relationsGeneratorTest($template, $tableName, $filesCount, $useClassConstant, $relationSets, ModelGenerator::JUNCTION_RELATION_VIA_TABLE);
     }
 
     /**
      * @dataProvider relationsProvider
      */
-    public function testViaModelRelationsGenerator($template, $tableName, $filesCount, $classNameResolution, $relationSets)
+    public function testViaModelRelationsGenerator($template, $tableName, $filesCount, $useClassConstant, $relationSets)
     {
-        $this->relationsGeneratorTest($template, $tableName, $filesCount, $classNameResolution, $relationSets, ModelGenerator::JUNCTION_RELATION_VIA_MODEL);
+        $this->relationsGeneratorTest($template, $tableName, $filesCount, $useClassConstant, $relationSets, ModelGenerator::JUNCTION_RELATION_VIA_MODEL);
     }
 
-    protected function relationsGeneratorTest($template, $tableName, $filesCount, $classNameResolution, $relationSets, $generateViaRelationMode)
+    protected function relationsGeneratorTest($template, $tableName, $filesCount, $useClassConstant, $relationSets, $generateViaRelationMode)
     {
         $generator = new ModelGenerator();
         $generator->template = $template;
         $generator->tableName = $tableName;
         $generator->generateRelationsFromCurrentSchema = false;
-        $generator->useClassNameResolutionConstant = $classNameResolution;
+        $generator->useClassConstant = $useClassConstant;
         $generator->generateJunctionRelationMode = $generateViaRelationMode;
 
         $files = $generator->generate();

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -35,7 +35,8 @@ class SchemaTest extends GiiTestCase
     public function relationsProvider()
     {
         return [
-            ['default', 'schema1.*', 5, [
+            // useClassNameResolutionConstant = false
+            ['default', 'schema1.*', 5, false, [
                 0 => [ // relations from junction1 table
                     "\$this->hasOne(Schema1Table1::className(), ['id' => 'table1_id']);",
                     "\$this->hasOne(Schema1MultiPk::className(), ['id1' => 'multi_pk_id1', 'id2' => 'multi_pk_id2']);",
@@ -76,11 +77,61 @@ class SchemaTest extends GiiTestCase
                     "\$this->hasMany(Schema1Junction2::className(), ['table1_id' => 'id']);",
                 ],
             ]],
-            ['default', 'schema2.*', 2, [
+            ['default', 'schema2.*', 2, false, [
                 0 => [
                     "\$this->hasOne(Schema1Table1::className(), ['fk2' => 'fk1', 'fk1' => 'fk2']);",
                     "\$this->hasOne(Schema1Table1::className(), ['fk4' => 'fk3', 'fk3' => 'fk4']);",
                     "\$this->hasOne(Schema2Table2::className(), ['fk5' => 'fk5', 'fk6' => 'fk6']);",
+                ],
+            ]],
+
+            // useClassNameResolutionConstant = true
+            ['default', 'schema1.*', 5, true, [
+                0 => [ // relations from junction1 table
+                    "\$this->hasOne(Schema1Table1::class, ['id' => 'table1_id']);",
+                    "\$this->hasOne(Schema1MultiPk::class, ['id1' => 'multi_pk_id1', 'id2' => 'multi_pk_id2']);",
+                ],
+                2 => [ // relations from multi_pk table
+                    [
+                        ModelGenerator::JUNCTION_RELATION_VIA_TABLE =>
+                            "\$this->hasMany(Schema1Table1::class, ['id' => 'table1_id'])->viaTable('junction1', ['multi_pk_id1' => 'id1', 'multi_pk_id2' => 'id2']);",
+                        ModelGenerator::JUNCTION_RELATION_VIA_MODEL =>
+                            "\$this->hasMany(Schema1Table1::class, ['id' => 'table1_id'])->via('schema1Junction1s');",
+                    ],
+                    [
+                        ModelGenerator::JUNCTION_RELATION_VIA_TABLE =>
+                            "\$this->hasMany(Schema1Table1::class, ['id' => 'table1_id'])->viaTable('junction2', ['multi_pk_id1' => 'id1', 'multi_pk_id2' => 'id2']);",
+                        ModelGenerator::JUNCTION_RELATION_VIA_MODEL =>
+                            "\$this->hasMany(Schema1Table1::class, ['id' => 'table1_id'])->via('schema1Junction2s');",
+                    ],
+                    "\$this->hasMany(Schema1Junction1::class, ['multi_pk_id1' => 'id1', 'multi_pk_id2' => 'id2']);",
+                    "\$this->hasMany(Schema1Junction2::class, ['multi_pk_id1' => 'id1', 'multi_pk_id2' => 'id2']);",
+                ],
+                3 => [ // relations from table1 table
+                    "\$this->hasMany(Schema2Table1::class, ['fk1' => 'fk2', 'fk2' => 'fk1']);",
+                    "\$this->hasMany(Schema2Table1::class, ['fk3' => 'fk4', 'fk4' => 'fk3']);",
+                    "\$this->hasOne(Schema2Table2::class, ['fk1' => 'fk1', 'fk2' => 'fk2']);",
+                    [
+                        ModelGenerator::JUNCTION_RELATION_VIA_TABLE =>
+                            "\$this->hasMany(Schema1MultiPk::class, ['id1' => 'multi_pk_id1', 'id2' => 'multi_pk_id2'])->viaTable('junction1', ['table1_id' => 'id']);",
+                        ModelGenerator::JUNCTION_RELATION_VIA_MODEL =>
+                            "\$this->hasMany(Schema1MultiPk::class, ['id1' => 'multi_pk_id1', 'id2' => 'multi_pk_id2'])->via('schema1Junction1s');",
+                    ],
+                    [
+                        ModelGenerator::JUNCTION_RELATION_VIA_TABLE =>
+                            "\$this->hasMany(Schema1MultiPk::class, ['id1' => 'multi_pk_id1', 'id2' => 'multi_pk_id2'])->viaTable('junction2', ['table1_id' => 'id']);",
+                        ModelGenerator::JUNCTION_RELATION_VIA_MODEL =>
+                            "\$this->hasMany(Schema1MultiPk::class, ['id1' => 'multi_pk_id1', 'id2' => 'multi_pk_id2'])->via('schema1Junction2s');",
+                    ],
+                    "\$this->hasMany(Schema1Junction1::class, ['table1_id' => 'id']);",
+                    "\$this->hasMany(Schema1Junction2::class, ['table1_id' => 'id']);",
+                ],
+            ]],
+            ['default', 'schema2.*', 2, true, [
+                0 => [
+                    "\$this->hasOne(Schema1Table1::class, ['fk2' => 'fk1', 'fk1' => 'fk2']);",
+                    "\$this->hasOne(Schema1Table1::class, ['fk4' => 'fk3', 'fk3' => 'fk4']);",
+                    "\$this->hasOne(Schema2Table2::class, ['fk5' => 'fk5', 'fk6' => 'fk6']);",
                 ],
             ]],
         ];
@@ -89,25 +140,26 @@ class SchemaTest extends GiiTestCase
     /**
      * @dataProvider relationsProvider
      */
-    public function testViaTableRelationsGenerator($template, $tableName, $filesCount, $relationSets)
+    public function testViaTableRelationsGenerator($template, $tableName, $filesCount, $classNameResolution, $relationSets)
     {
-        $this->relationsGeneratorTest($template, $tableName, $filesCount, $relationSets, ModelGenerator::JUNCTION_RELATION_VIA_TABLE);
+        $this->relationsGeneratorTest($template, $tableName, $filesCount, $classNameResolution, $relationSets, ModelGenerator::JUNCTION_RELATION_VIA_TABLE);
     }
 
     /**
      * @dataProvider relationsProvider
      */
-    public function testViaModelRelationsGenerator($template, $tableName, $filesCount, $relationSets)
+    public function testViaModelRelationsGenerator($template, $tableName, $filesCount, $classNameResolution, $relationSets)
     {
-        $this->relationsGeneratorTest($template, $tableName, $filesCount, $relationSets, ModelGenerator::JUNCTION_RELATION_VIA_MODEL);
+        $this->relationsGeneratorTest($template, $tableName, $filesCount, $classNameResolution, $relationSets, ModelGenerator::JUNCTION_RELATION_VIA_MODEL);
     }
 
-    protected function relationsGeneratorTest($template, $tableName, $filesCount, $relationSets, $generateViaRelationMode)
+    protected function relationsGeneratorTest($template, $tableName, $filesCount, $classNameResolution, $relationSets, $generateViaRelationMode)
     {
         $generator = new ModelGenerator();
         $generator->template = $template;
         $generator->tableName = $tableName;
         $generator->generateRelationsFromCurrentSchema = false;
+        $generator->useClassNameResolutionConstant = $classNameResolution;
         $generator->generateJunctionRelationMode = $generateViaRelationMode;
 
         $files = $generator->generate();

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -10,23 +10,23 @@ use yiiunit\gii\GiiTestCase;
  */
 class ModelGeneratorTest extends GiiTestCase
 {
-    public function testDefaultUseClassNameResolutionConstant()
+    public function testDefaultuseClassConstant()
     {
         $generator = new ModelGenerator();
         $this->assertEquals(
             PHP_MAJOR_VERSION > 5  || (PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION > 4),
-            $generator->useClassNameResolutionConstant
+            $generator->useClassConstant
         );
 
         $generator = new ModelGenerator([
-            'useClassNameResolutionConstant' => false,
+            'useClassConstant' => false,
         ]);
-        $this->assertFalse($generator->useClassNameResolutionConstant);
+        $this->assertFalse($generator->useClassConstant);
 
         $generator = new ModelGenerator([
-            'useClassNameResolutionConstant' => true,
+            'useClassConstant' => true,
         ]);
-        $this->assertTrue($generator->useClassNameResolutionConstant);
+        $this->assertTrue($generator->useClassConstant);
     }
 
     public function testAll()
@@ -175,7 +175,7 @@ class ModelGeneratorTest extends GiiTestCase
                 ],
             ]],
 
-            // useClassNameResolutionConstant = true
+            // useClassConstant = true
             ['category', 'Category.php', true, [
                 [
                     'name' => 'function getCategoryPhotos()',
@@ -195,15 +195,15 @@ class ModelGeneratorTest extends GiiTestCase
      * @dataProvider relationsProvider
      * @param $tableName string
      * @param $fileName string
-     * @param $classNameResolution bool
+     * @param $useClassConstant bool
      * @param $relations array
      */
-    public function testRelations($tableName, $fileName, $classNameResolution, $relations)
+    public function testRelations($tableName, $fileName, $useClassConstant, $relations)
     {
         $generator = new ModelGenerator();
         $generator->template = 'default';
         $generator->generateRelationsFromCurrentSchema = false;
-        $generator->useClassNameResolutionConstant = $classNameResolution;
+        $generator->useClassConstant = $useClassConstant;
         $generator->tableName = $tableName;
 
         $files = $generator->generate();
@@ -251,7 +251,7 @@ class ModelGeneratorTest extends GiiTestCase
                 "[['id', 'supplier_id'], 'unique', 'targetAttribute' => ['id', 'supplier_id']]",
             ]],
 
-            // useClassNameResolutionConstant = true
+            // useClassConstant = true
             ['product_language', 'ProductLanguage.php', true, [
                 "[['supplier_id', 'id'], 'exist', 'skipOnError' => true, 'targetClass' => Product::class, 'targetAttribute' => ['supplier_id' => 'supplier_id', 'id' => 'id']],",
                 "[['supplier_id'], 'exist', 'skipOnError' => true, 'targetClass' => Supplier::class, 'targetAttribute' => ['supplier_id' => 'id']],",
@@ -267,15 +267,15 @@ class ModelGeneratorTest extends GiiTestCase
      *
      * @param $tableName string
      * @param $fileName string
-     * @param $classNameResolution bool
+     * @param $useClassConstant bool
      * @param $rules array
      */
-    public function testRules($tableName, $fileName, $classNameResolution, $rules)
+    public function testRules($tableName, $fileName, $useClassConstant, $rules)
     {
         $generator = new ModelGenerator();
         $generator->template = 'default';
         $generator->tableName = $tableName;
-        $generator->useClassNameResolutionConstant = $classNameResolution;
+        $generator->useClassConstant = $useClassConstant;
 
         $files = $generator->generate();
         $this->assertEquals(1, count($files));

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -10,6 +10,25 @@ use yiiunit\gii\GiiTestCase;
  */
 class ModelGeneratorTest extends GiiTestCase
 {
+    public function testDefaultUseClassNameResolutionConstant()
+    {
+        $generator = new ModelGenerator();
+        $this->assertEquals(
+            PHP_MAJOR_VERSION > 5  || (PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION > 5),
+            $generator->useClassNameResolutionConstant
+        );
+
+        $generator = new ModelGenerator([
+            'useClassNameResolutionConstant' => false,
+        ]);
+        $this->assertFalse($generator->useClassNameResolutionConstant);
+
+        $generator = new ModelGenerator([
+            'useClassNameResolutionConstant' => true,
+        ]);
+        $this->assertTrue($generator->useClassNameResolutionConstant);
+    }
+
     public function testAll()
     {
         $generator = new ModelGenerator();

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -14,7 +14,7 @@ class ModelGeneratorTest extends GiiTestCase
     {
         $generator = new ModelGenerator();
         $this->assertEquals(
-            PHP_MAJOR_VERSION > 5  || (PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION > 5),
+            PHP_MAJOR_VERSION > 5  || (PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION > 4),
             $generator->useClassNameResolutionConstant
         );
 

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -56,7 +56,7 @@ class ModelGeneratorTest extends GiiTestCase
     public function relationsProvider()
     {
         return [
-            ['category', 'Category.php', [
+            ['category', 'Category.php', false, [
                 [
                     'name' => 'function getCategoryPhotos()',
                     'relation' => "\$this->hasMany(CategoryPhoto::className(), ['category_id' => 'id']);",
@@ -68,14 +68,14 @@ class ModelGeneratorTest extends GiiTestCase
                     'expected' => true,
                 ],
             ]],
-            ['category_photo', 'CategoryPhoto.php', [
+            ['category_photo', 'CategoryPhoto.php', false, [
                 [
                     'name' => 'function getCategory()',
                     'relation' => "\$this->hasOne(Category::className(), ['id' => 'category_id']);",
                     'expected' => true,
                 ],
             ]],
-            ['supplier', 'Supplier.php', [
+            ['supplier', 'Supplier.php', false, [
                 [
                     'name' => 'function getProducts()',
                     'relation' => "\$this->hasMany(Product::className(), ['supplier_id' => 'id']);",
@@ -97,7 +97,7 @@ class ModelGeneratorTest extends GiiTestCase
                     'expected' => true,
                 ],
             ]],
-            ['product', 'Product.php', [
+            ['product', 'Product.php', false, [
                 [
                     'name' => 'function getSupplier()',
                     'relation' => "\$this->hasOne(Supplier::className(), ['id' => 'supplier_id']);",
@@ -114,7 +114,7 @@ class ModelGeneratorTest extends GiiTestCase
                     'expected' => true,
                 ],
             ]],
-            ['product_language', 'ProductLanguage.php', [
+            ['product_language', 'ProductLanguage.php', false, [
                 [
                     'name' => 'function getSupplier()',
                     'relation' => "\$this->hasOne(Product::className(), ['supplier_id' => 'supplier_id', 'id' => 'id']);",
@@ -127,31 +127,45 @@ class ModelGeneratorTest extends GiiTestCase
                 ],
             ]],
 
-            ['organization', 'Organization.php', [
+            ['organization', 'Organization.php', false, [
                 [
                     'name' => 'function getIdentityProviders()',
                     'relation' => "\$this->hasMany(IdentityProvider::className(), ['organization_id' => 'id']);",
                     'expected' => true,
                 ],
             ]],
-            ['identity_provider', 'IdentityProvider.php', [
+            ['identity_provider', 'IdentityProvider.php', false, [
                 [
                     'name' => 'function getOrganization()',
                     'relation' => "\$this->hasOne(Organization::className(), ['id' => 'organization_id']);",
                     'expected' => true,
                 ],
             ]],
-            ['user_rtl', 'UserRtl.php', [
+            ['user_rtl', 'UserRtl.php', false, [
                 [
                     'name' => 'function getBlogRtls()',
                     'relation' => "\$this->hasMany(BlogRtl::className(), ['id_user' => 'id']);",
                     'expected' => true,
                 ],
             ]],
-            ['blog_rtl', 'BlogRtl.php', [
+            ['blog_rtl', 'BlogRtl.php', false, [
                 [
                     'name' => 'function getUser()',
                     'relation' => "\$this->hasOne(UserRtl::className(), ['id' => 'id_user']);",
+                    'expected' => true,
+                ],
+            ]],
+
+            // useClassNameResolutionConstant = true
+            ['category', 'Category.php', true, [
+                [
+                    'name' => 'function getCategoryPhotos()',
+                    'relation' => "\$this->hasMany(CategoryPhoto::class, ['category_id' => 'id']);",
+                    'expected' => true,
+                ],
+                [
+                    'name' => 'function getProduct()',
+                    'relation' => "\$this->hasOne(Product::class, ['category_id' => 'id', 'category_language_code' => 'language_code']);",
                     'expected' => true,
                 ],
             ]],
@@ -162,13 +176,15 @@ class ModelGeneratorTest extends GiiTestCase
      * @dataProvider relationsProvider
      * @param $tableName string
      * @param $fileName string
+     * @param $classNameResolution bool
      * @param $relations array
      */
-    public function testRelations($tableName, $fileName, $relations)
+    public function testRelations($tableName, $fileName, $classNameResolution, $relations)
     {
         $generator = new ModelGenerator();
         $generator->template = 'default';
         $generator->generateRelationsFromCurrentSchema = false;
+        $generator->useClassNameResolutionConstant = $classNameResolution;
         $generator->tableName = $tableName;
 
         $files = $generator->generate();
@@ -199,18 +215,27 @@ class ModelGeneratorTest extends GiiTestCase
     public function rulesProvider()
     {
         return [
-            ['category_photo', 'CategoryPhoto.php', [
+            ['category_photo', 'CategoryPhoto.php', false, [
                 "[['category_id'], 'exist', 'skipOnError' => true, 'targetClass' => Category::className(), 'targetAttribute' => ['category_id' => 'id']],",
                 "[['category_id', 'display_number'], 'unique', 'targetAttribute' => ['category_id', 'display_number']],",
             ]],
-            ['product', 'Product.php', [
+            ['product', 'Product.php', false, [
                 "[['supplier_id'], 'exist', 'skipOnError' => true, 'targetClass' => Supplier::className(), 'targetAttribute' => ['supplier_id' => 'id']],",
                 "[['category_id', 'category_language_code'], 'exist', 'skipOnError' => true, 'targetClass' => Category::className(), 'targetAttribute' => ['category_id' => 'id', 'category_language_code' => 'language_code']],",
                 "[['category_id', 'category_language_code'], 'unique', 'targetAttribute' => ['category_id', 'category_language_code']],"
             ]],
-            ['product_language', 'ProductLanguage.php', [
+            ['product_language', 'ProductLanguage.php', false, [
                 "[['supplier_id', 'id'], 'exist', 'skipOnError' => true, 'targetClass' => Product::className(), 'targetAttribute' => ['supplier_id' => 'supplier_id', 'id' => 'id']],",
                 "[['supplier_id'], 'exist', 'skipOnError' => true, 'targetClass' => Supplier::className(), 'targetAttribute' => ['supplier_id' => 'id']],",
+                "[['supplier_id'], 'unique']",
+                "[['id', 'supplier_id', 'language_code'], 'unique', 'targetAttribute' => ['id', 'supplier_id', 'language_code']]",
+                "[['id', 'supplier_id'], 'unique', 'targetAttribute' => ['id', 'supplier_id']]",
+            ]],
+
+            // useClassNameResolutionConstant = true
+            ['product_language', 'ProductLanguage.php', true, [
+                "[['supplier_id', 'id'], 'exist', 'skipOnError' => true, 'targetClass' => Product::class, 'targetAttribute' => ['supplier_id' => 'supplier_id', 'id' => 'id']],",
+                "[['supplier_id'], 'exist', 'skipOnError' => true, 'targetClass' => Supplier::class, 'targetAttribute' => ['supplier_id' => 'id']],",
                 "[['supplier_id'], 'unique']",
                 "[['id', 'supplier_id', 'language_code'], 'unique', 'targetAttribute' => ['id', 'supplier_id', 'language_code']]",
                 "[['id', 'supplier_id'], 'unique', 'targetAttribute' => ['id', 'supplier_id']]",
@@ -223,13 +248,15 @@ class ModelGeneratorTest extends GiiTestCase
      *
      * @param $tableName string
      * @param $fileName string
+     * @param $classNameResolution bool
      * @param $rules array
      */
-    public function testRules($tableName, $fileName, $rules)
+    public function testRules($tableName, $fileName, $classNameResolution, $rules)
     {
         $generator = new ModelGenerator();
         $generator->template = 'default';
         $generator->tableName = $tableName;
+        $generator->useClassNameResolutionConstant = $classNameResolution;
 
         $files = $generator->generate();
         $this->assertEquals(1, count($files));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #305, #342, #356, #400, #403, #427, #437, #493

This PR adds the `useClassConstant` option to the model generator. When `true` `::class` instead of `::className()` is used.

~~At the moment the default value for `useClassNameResolutionConstant` is `false`. We could decide to set it to `true` since only users on PHP 5.4 would need the old method.~~
Update 2022-06-15:
The default value for `useClassConstant` is `null` which means it will be automatically resolved to `true` if the PHP version >= 5.5 and to `false` ortherwise. Fixing it to either `true` or `false` is also possible.