### PR TITLE
Added support for field types 'date', 'datetime' & 'time'

### DIFF
--- a/src/generators/crud/Generator.php
+++ b/src/generators/crud/Generator.php
@@ -275,6 +275,10 @@ class Generator extends \yii\gii\Generator
             return "\$form->field(\$model, '$attribute')->textInput(['type' => 'datetime-local'])";
         }
 
+        if ($column->type === Schema::TYPE_TIME) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'time'])";
+        }
+
         if ($column->type === 'text') {
             return "\$form->field(\$model, '$attribute')->textarea(['rows' => 6])";
         }
@@ -324,6 +328,10 @@ class Generator extends \yii\gii\Generator
 
         if ($column->type === Schema::TYPE_DATETIME) {
             return "\$form->field(\$model, '$attribute')->textInput(['type' => 'datetime-local'])";
+        }
+
+        if ($column->type === Schema::TYPE_TIME) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'time'])";
         }
 
         return "\$form->field(\$model, '$attribute')";

--- a/src/generators/crud/Generator.php
+++ b/src/generators/crud/Generator.php
@@ -267,6 +267,14 @@ class Generator extends \yii\gii\Generator
             return "\$form->field(\$model, '$attribute')->checkbox()";
         }
 
+        if ($column->type === Schema::TYPE_DATE) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'date'])";
+        }
+
+        if ($column->type === Schema::TYPE_DATETIME) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'datetime-local'])";
+        }
+
         if ($column->type === 'text') {
             return "\$form->field(\$model, '$attribute')->textarea(['rows' => 6])";
         }
@@ -308,6 +316,14 @@ class Generator extends \yii\gii\Generator
         $column = $tableSchema->columns[$attribute];
         if ($column->phpType === 'boolean') {
             return "\$form->field(\$model, '$attribute')->checkbox()";
+        }
+
+        if ($column->type === Schema::TYPE_DATE) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'date'])";
+        }
+
+        if ($column->type === Schema::TYPE_DATETIME) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'datetime-local'])";
         }
 
         return "\$form->field(\$model, '$attribute')";


### PR DESCRIPTION
Added input field of type 'date', 'datetime' & 'time' in form/search fields.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

