### PR TITLE
Added use statement for model namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.2.5 under development
 -----------------------
 
-- no changes in this release.
+- Bug #500: Fix missing namespace in CRUD index template (mohamed-nazim)
 
 
 2.2.4 December 30, 2021

--- a/src/generators/crud/default/views/index.php
+++ b/src/generators/crud/default/views/index.php
@@ -11,6 +11,7 @@ $modelClass = StringHelper::basename($generator->modelClass);
 echo "<?php\n";
 ?>
 
+use <?= $generator->modelClass ?>;
 use yii\helpers\Html;
 use yii\helpers\Url;
 use yii\grid\ActionColumn;


### PR DESCRIPTION
php 7.4 is giving errors about missing namespace use statement because the 'urlCreator' closure uses '$modelClass' that doesn't have a namespace, and results in 'Argument 2 passed to yii\base\View::{closure}() must be an instance of ModelClassName'

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
