### PR TITLE
Date time fields support in crud form

### DIFF
--- a/src/generators/crud/Generator.php
+++ b/src/generators/crud/Generator.php
@@ -275,6 +275,10 @@ class Generator extends \yii\gii\Generator
             return "\$form->field(\$model, '$attribute')->textInput(['type' => 'datetime-local'])";
         }
 
+        if ($column->type === Schema::TYPE_TIME) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'time'])";
+        }
+
         if ($column->type === 'text') {
             return "\$form->field(\$model, '$attribute')->textarea(['rows' => 6])";
         }
@@ -324,6 +328,10 @@ class Generator extends \yii\gii\Generator
 
         if ($column->type === Schema::TYPE_DATETIME) {
             return "\$form->field(\$model, '$attribute')->textInput(['type' => 'datetime-local'])";
+        }
+
+        if ($column->type === Schema::TYPE_TIME) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'time'])";
         }
 
         return "\$form->field(\$model, '$attribute')";

--- a/src/generators/crud/Generator.php
+++ b/src/generators/crud/Generator.php
@@ -267,6 +267,14 @@ class Generator extends \yii\gii\Generator
             return "\$form->field(\$model, '$attribute')->checkbox()";
         }
 
+        if ($column->type === Schema::TYPE_DATE) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'date'])";
+        }
+
+        if ($column->type === Schema::TYPE_DATETIME) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'datetime-local'])";
+        }
+
         if ($column->type === 'text') {
             return "\$form->field(\$model, '$attribute')->textarea(['rows' => 6])";
         }
@@ -308,6 +316,14 @@ class Generator extends \yii\gii\Generator
         $column = $tableSchema->columns[$attribute];
         if ($column->phpType === 'boolean') {
             return "\$form->field(\$model, '$attribute')->checkbox()";
+        }
+
+        if ($column->type === Schema::TYPE_DATE) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'date'])";
+        }
+
+        if ($column->type === Schema::TYPE_DATETIME) {
+            return "\$form->field(\$model, '$attribute')->textInput(['type' => 'datetime-local'])";
         }
 
         return "\$form->field(\$model, '$attribute')";


### PR DESCRIPTION
Updated my branch name for the previous [PR](https://github.com/yiisoft/yii2-gii/pull/499) and it ended up closed. So resubmitting.

This PR adds support for input field of type 'date', 'datetime' & 'time' in form/search fields and is based on current browser standards for date / date time input field. MDN [definition](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date) for `date` says it uses `YYYY-MM-DD` standard and the [definition](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local) for `datetime-local` uses `YYYY-MM-DDT00:00` standard - which is what is sent over when the form is submitted (although what is rendered on the screen is based on local device settings/locale).

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

