### PR TITLE
Added skipOnEmpty for trim filter in generators/model/Generator.php

### DIFF
--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -99,7 +99,7 @@ class Generator extends \yii\gii\Generator
     public function rules()
     {
         return array_merge(parent::rules(), [
-            [['db', 'tableName', 'modelClass', 'baseClass', 'queryClass', 'queryBaseClass'], 'filter', 'filter' => 'trim'],
+            [['db', 'tableName', 'modelClass', 'baseClass', 'queryClass', 'queryBaseClass'], 'filter', 'filter' => 'trim', 'skipOnEmpty' => true],
             [
                 ['ns', 'queryNs'],
                 'filter',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Fixes compatibility with PHP 8.1, see yiisoft/yii2/pull/19323