### PR TITLE
on singularize checkbox click, generate the model name again

### DIFF
--- a/src/assets/js/gii.js
+++ b/src/assets/js/gii.js
@@ -212,7 +212,26 @@ yii.gii = (function ($) {
                 }
                 $('.field-generator-caseinsensitive').toggle(!show);
             }).change();
+            $("#generator-singularize").click(function () {
+                var $this = $(this);
+                var $modelClass = $('#generator-modelclass');
+                getModelClassName($this, $modelClass);
+            })
 
+            function getModelClassName($this, $modelClass) {
+                ajaxRequest = $.ajax({
+                    type: 'POST',
+                    cache: false,
+                    url: $this.data('action'),
+                    data: $('#model-generator').serializeArray(),
+                    success: function (response) {
+                        $modelClass.val(response).blur();
+                    },
+                    error: function (XMLHttpRequest, textStatus, errorThrown) {
+                        $modal.find('.modal-body').html('<div class="error">' + XMLHttpRequest.responseText + '</div>');
+                    }
+                });
+            }
             // model generator: translate table name to model class
             $('#model-generator #generator-tablename').on('blur', function () {
                 var $this = $(this);

--- a/src/generators/model/form.php
+++ b/src/generators/model/form.php
@@ -18,7 +18,12 @@ echo $form->field($generator, 'tableName')->textInput([
     ]
 ]);
 echo $form->field($generator, 'standardizeCapitals')->checkbox();
-echo $form->field($generator, 'singularize')->checkbox();
+echo $form->field($generator, 'singularize')->checkbox([
+    'data' => [
+        'table-prefix' => $generator->getTablePrefix(),
+        'action' => Url::to(['default/action', 'id' => 'model', 'name' => 'GenerateClassName'])
+    ]
+]);
 echo $form->field($generator, 'modelClass');
 echo $form->field($generator, 'ns');
 echo $form->field($generator, 'baseClass');


### PR DESCRIPTION
In gii model generator, if singularize checkbox is clicked it will send a request to Generator to re-generate model name again. this make easy to get singular or default model name, without even clearing the modelClass textbox and then again triggering the blur event from tableName textbox. 

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
