### PR TITLE
Fix validation for `messageCategory`

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -400,7 +400,7 @@ abstract class Generator extends Model
         if ($this->enableI18N) {
             if (empty($this->messageCategory)) {
                 $this->addError('messageCategory', "Message Category cannot be blank.");
-            } elseif (!preg_match('~\w+~', $this->messageCategory)) {
+            } elseif (!preg_match('~^\w+$~', $this->messageCategory)) {
                 $this->addError('messageCategory', "Message Category is not valid. It should contain only alphanumeric characters and _.");
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Previous regexp matched strings like `<div>`.