### PR TITLE
Update regexp for `messageCategory` validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.2.6 under development
 -----------------------
 
-- no changes in this release.
+- Bug #511: Fix validation for `messageCategory` in Generator (rob006)
 
 
 2.2.5 September 04, 2022
@@ -21,7 +21,7 @@ Yii Framework 2 gii extension Change Log
 - Bug #467: Fix view `generators/crud/default/controller` (WinterSilence, cjrf)
 - Bug #476: Fix stucking datalist options in form generator (WinterSilence)
 - Bug #484: Add parent's labels and hints, fix rule for attribute `moduleClass` in module generator (WinterSilence)
-- Bug #486: Update `assets/js/bs4-native.min.js` to latest version (WinterSilence)
+- Bug #486: Update `assets/js/bs4-native.min.js` to the latest version (WinterSilence)
 - Bug #488: Fix `ActionColumn::$urlCreator` in index template of CRUD generator (WinterSilence)
 - Enh #485: Add validation rules for `enableI18N` and `messageCategory` to Generator (WinterSilence)
 

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,10 @@
         "process-timeout": 1800,
         "fxp-asset": {
             "enabled": false
+        },
+        "allow-plugins": {
+            "cweagans/composer-patches": true,
+            "yiisoft/yii2-composer": true
         }
     },
     "repositories": [

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -399,9 +399,9 @@ abstract class Generator extends Model
     {
         if ($this->enableI18N) {
             if (empty($this->messageCategory)) {
-                $this->addError('messageCategory', "Message Category cannot be blank.");
-            } elseif (!preg_match('~^\w+$~', $this->messageCategory)) {
-                $this->addError('messageCategory', "Message Category is not valid. It should contain only alphanumeric characters and _.");
+                $this->addError('messageCategory', 'Message Category cannot be blank.');
+            } elseif (!preg_match('~^[\w./-]+$~', $this->messageCategory)) {
+                $this->addError('messageCategory', 'Message Category is not valid. It should contain only alphanumeric characters, ".", "-", "/", and "_".');
             }
         }
     }


### PR DESCRIPTION
Appendix for https://github.com/yiisoft/yii2-gii/pull/511. While it fixed original intentions from https://github.com/yiisoft/yii2-gii/pull/456, it seem to be too restrictive. Even documentation proposes categories like `app/error`, so it does not make sense to disallow `/` character. In addition to that `.` and `-` could be also useful for message categories.