### PR TITLE
Bug #525 added into CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 gii extension Change Log
 - Bug #510: Fix possible XSS (rob006)
 - Bug #511: Fix validation for `messageCategory` in Generator (rob006)
 - Enh #514: Fix compatibility with PHP 8.1 and 8.2 (rob006)
+- Bug #525: Fix of the modal dialog visibility with a preview of generated migration
 
 
 2.2.5 September 04, 2022


### PR DESCRIPTION
Fix of the modal dialog visibility with a preview of generated migration.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #525 
