### PR TITLE
Update GenerateAction.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 2.2.7 under development
 -----------------------
 
-- no changes in this release.
+- Bug #531: Fix `yii\gii\console\GenerateAction` to use `stdout()` instead of echoing the output (egmsystems)
 
 
 2.2.6 May 22, 2023

--- a/src/console/GenerateAction.php
+++ b/src/console/GenerateAction.php
@@ -43,9 +43,9 @@ class GenerateAction extends \yii\base\Action
     {
         $this->controller->stdout("Code not generated. Please fix the following errors:\n\n", Console::FG_RED);
         foreach ($this->generator->errors as $attribute => $errors) {
-            echo ' - ' . $this->controller->ansiFormat($attribute, Console::FG_CYAN) . ': ' . implode('; ', $errors) . "\n";
+            $this->controller->stdout(' - ' . $this->controller->ansiFormat($attribute, Console::FG_CYAN) . ': ' . implode('; ', $errors) . "\n");
         }
-        echo "\n";
+        $this->controller->stdout("\n");
     }
 
     protected function generateCode()


### PR DESCRIPTION
$this->controller->stdout("Code not generated. Please fix the following errors:\n\n", Console::FG_RED); print fine but the next echo not show inmediatly  and better replace echo with $this->controller->stdout

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
