### PR TITLE
Update GenerateAction.php

### DIFF
--- a/src/console/GenerateAction.php
+++ b/src/console/GenerateAction.php
@@ -36,6 +36,7 @@ class GenerateAction extends \yii\base\Action
             $this->generateCode();
         } else {
             $this->displayValidationErrors();
+            return \yii\console\ExitCode::USAGE;
         }
     }
 


### PR DESCRIPTION
add after $this->displayValidationErrors();
return \yii\console\ExitCode::USAGE;
to compare with \yii\console\ExitCode::OK

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
