### PR TITLE
Generating rules for the fields with default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 gii extension Change Log
 -----------------------
 
 - Bug #532: Return `ExitCode::USAGE` on command input validation error (egmsystems)
+- Enh #537: Generating rules for the fields with default values (manky)  q
 
 
 2.2.6 May 22, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 gii extension Change Log
 -----------------------
 
 - Bug #532: Return `ExitCode::USAGE` on command input validation error (egmsystems)
-- Enh #537: Generating rules for the fields with default values (manky)  q
+- Enh #537: Generating rules for the fields with default values (manky)
 
 
 2.2.6 May 22, 2023

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -491,7 +491,8 @@ class Generator extends \yii\gii\Generator
         }
         if (!empty($defaultValues)) {
             foreach ($defaultValues as $defaultValue => $defaultValueColumns) {
-                $rules[] = "[['" . implode("', '", $defaultValueColumns) . "'], 'default', 'value' => '$defaultValue']";
+                $defaultValue = is_numeric($defaultValue) ? $defaultValue : "'$defaultValue'";
+                $rules[] = "[['" . implode("', '", $defaultValueColumns) . "'], 'default', 'value' => $defaultValue]";
             }
         }
         $driverName = $this->getDbDriverName();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

This may sound unimportant, but if you are using **yii\behaviors\AttributeTypecastBehavior** and the cast depends on the **rules()** method of your model, for example, fields validated via **yii\validators\NumberValidator** and without any value will be cast to integer/float. So the value of the empty fields will become **0** 

_An important part is that default rules should be at the beginning of the rule list._
