### PR TITLE
Use the name of the table to create the relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 gii extension Change Log
 
 - Bug #532: Return `ExitCode::USAGE` on command input validation error (egmsystems)
 - Enh #537: Generating rules for the fields with default values (manky)
+- Enh #542: Use the table name to create the relation (thiagotalma)
 
 
 2.2.6 May 22, 2023

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -154,7 +154,7 @@ class Generator extends \yii\gii\Generator
             'generateRelations' => 'Generate Relations',
             'generateJunctionRelationMode' => 'Generate Junction Relations As',
             'generateRelationsFromCurrentSchema' => 'Generate Relations from Current Schema',
-            'generateRelationNameFromDestinationTable' => 'Generate Relations Name Using Destination Table Name',
+            'generateRelationNameFromDestinationTable' => 'Generate Relation Names Using Target Table Name',
             'useClassConstant' => 'Use `::class`',
             'generateLabelsFromComments' => 'Generate Labels from DB Comments',
             'generateQuery' => 'Generate ActiveQuery',
@@ -197,7 +197,7 @@ class Generator extends \yii\gii\Generator
                 Make sure you also generate the junction models when using the "Via Model" option.
             ',
             'generateRelationsFromCurrentSchema' => 'This indicates whether the generator should generate relations from current schema or from all available schemas.',
-            'generateRelationNameFromDestinationTable' => 'This indicates whether the relation name should reflect the target table name.',
+            'generateRelationNameFromDestinationTable' => 'This indicates whether the relation names should use target table name.',
             'useClassConstant' => 'Use the `::class` constant instead of the `::className()` method.',
             'generateLabelsFromComments' => 'This indicates whether the generator should generate attribute labels
                 by using the comments of the corresponding DB columns.',

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -682,6 +682,7 @@ class Generator extends \yii\gii\Generator
                         // Foreign key could point to non-existing table: https://github.com/yiisoft/yii2-gii/issues/34
                         continue;
                     }
+                    $relName = $refs[0];
                     unset($refs[0]);
                     $fks = array_keys($refs);
                     $refClassName = $this->generateClassName($refTable);
@@ -689,7 +690,7 @@ class Generator extends \yii\gii\Generator
 
                     // Add relation for this table
                     $link = $this->generateRelationLink(array_flip($refs));
-                    $relationName = $this->generateRelationName($relations, $table, $fks[0], false);
+                    $relationName = $this->generateRelationName($relations, $table, $relName, false);
                     $relations[$table->fullName][$relationName] = [
                         "return \$this->hasOne($refClassNameResolution, $link);",
                         $refClassName,

--- a/src/generators/model/form.php
+++ b/src/generators/model/form.php
@@ -32,6 +32,7 @@ echo $form->field($generator, 'generateJunctionRelationMode')->dropDownList([
     Generator::JUNCTION_RELATION_VIA_MODEL => 'Via Model',
 ]);
 echo $form->field($generator, 'generateRelationsFromCurrentSchema')->checkbox();
+echo $form->field($generator, 'generateRelationNameFromDestinationTable')->checkbox();
 echo $form->field($generator, 'useClassConstant')->checkbox();
 echo $form->field($generator, 'generateLabelsFromComments')->checkbox();
 echo $form->field($generator, 'generateQuery')->checkbox();

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -220,6 +220,7 @@ class ModelGeneratorTest extends GiiTestCase
      * @param $fileName string
      * @param $useClassConstant bool
      * @param $relations array
+     * @param $fromDestTable bool
      */
     public function testRelations($tableName, $fileName, $useClassConstant, $relations, $fromDestTable = false)
     {

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -135,6 +135,18 @@ class ModelGeneratorTest extends GiiTestCase
             ]],
             ['product_language', 'ProductLanguage.php', false, [
                 [
+                    'name' => 'function getSupplier()',
+                    'relation' => "\$this->hasOne(Product::className(), ['supplier_id' => 'supplier_id', 'id' => 'id']);",
+                    'expected' => true,
+                ],
+                [
+                    'name' => 'function getSupplier0()',
+                    'relation' => "\$this->hasOne(Supplier::className(), ['id' => 'supplier_id']);",
+                    'expected' => true,
+                ],
+            ]],
+            ['product_language', 'ProductLanguage.php', false, [
+                [
                     'name' => 'function getProduct()',
                     'relation' => "\$this->hasOne(Product::className(), ['supplier_id' => 'supplier_id', 'id' => 'id']);",
                     'expected' => true,
@@ -144,7 +156,9 @@ class ModelGeneratorTest extends GiiTestCase
                     'relation' => "\$this->hasOne(Supplier::className(), ['id' => 'supplier_id']);",
                     'expected' => true,
                 ],
-            ]],
+            ],
+             true // $fromDestTable
+            ],
 
             ['organization', 'Organization.php', false, [
                 [
@@ -169,11 +183,20 @@ class ModelGeneratorTest extends GiiTestCase
             ]],
             ['blog_rtl', 'BlogRtl.php', false, [
                 [
-                    'name' => 'function getUserRtl()',
+                    'name' => 'function getUser()',
                     'relation' => "\$this->hasOne(UserRtl::className(), ['id' => 'id_user']);",
                     'expected' => true,
                 ],
             ]],
+            ['blog_rtl', 'BlogRtl.php', false, [
+                [
+                    'name' => 'function getUserRtl()',
+                    'relation' => "\$this->hasOne(UserRtl::className(), ['id' => 'id_user']);",
+                    'expected' => true,
+                ],
+            ],
+             true
+            ],
 
             // useClassConstant = true
             ['category', 'Category.php', true, [
@@ -198,12 +221,12 @@ class ModelGeneratorTest extends GiiTestCase
      * @param $useClassConstant bool
      * @param $relations array
      */
-    public function testRelations($tableName, $fileName, $useClassConstant, $relations)
+    public function testRelations($tableName, $fileName, $useClassConstant, $relations, $fromDestTable = false)
     {
         $generator = new ModelGenerator();
         $generator->template = 'default';
         $generator->generateRelationsFromCurrentSchema = false;
-        $generator->generateRelationNameFromDestinationTable = true;
+        $generator->generateRelationNameFromDestinationTable = $fromDestTable;
         $generator->useClassConstant = $useClassConstant;
         $generator->tableName = $tableName;
 

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -203,6 +203,7 @@ class ModelGeneratorTest extends GiiTestCase
         $generator = new ModelGenerator();
         $generator->template = 'default';
         $generator->generateRelationsFromCurrentSchema = false;
+        $generator->generateRelationNameFromDestinationTable = false;
         $generator->useClassConstant = $useClassConstant;
         $generator->tableName = $tableName;
 

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -135,12 +135,12 @@ class ModelGeneratorTest extends GiiTestCase
             ]],
             ['product_language', 'ProductLanguage.php', false, [
                 [
-                    'name' => 'function getSupplier()',
+                    'name' => 'function getProduct()',
                     'relation' => "\$this->hasOne(Product::className(), ['supplier_id' => 'supplier_id', 'id' => 'id']);",
                     'expected' => true,
                 ],
                 [
-                    'name' => 'function getSupplier0()',
+                    'name' => 'function getSupplier()',
                     'relation' => "\$this->hasOne(Supplier::className(), ['id' => 'supplier_id']);",
                     'expected' => true,
                 ],

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -169,7 +169,7 @@ class ModelGeneratorTest extends GiiTestCase
             ]],
             ['blog_rtl', 'BlogRtl.php', false, [
                 [
-                    'name' => 'function getUser()',
+                    'name' => 'function getUserRtl()',
                     'relation' => "\$this->hasOne(UserRtl::className(), ['id' => 'id_user']);",
                     'expected' => true,
                 ],

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -203,7 +203,7 @@ class ModelGeneratorTest extends GiiTestCase
         $generator = new ModelGenerator();
         $generator->template = 'default';
         $generator->generateRelationsFromCurrentSchema = false;
-        $generator->generateRelationNameFromDestinationTable = false;
+        $generator->generateRelationNameFromDestinationTable = true;
         $generator->useClassConstant = $useClassConstant;
         $generator->tableName = $tableName;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

Use the real name of the table to create the relationship when there is a composite primary key.

Prevents the generation of random relationship names.

**Turn this:**

```PHP
<?php

(...)

/**
 *
 * @property int $id
 * @property int $employee_id
 *
 * @property Employee $employee
 * @property Route $employee0 <---
 */
class Company extends \yii\db\ActiveRecord
{
    (...)

    /**
     * Gets query for [[Employee]].
     *
     * @return \yii\db\ActiveQuery
     */
    public function getEmployee()
    {
        return $this->hasOne(Employee::class, ['id' => 'employee_id']);
    }

    /**
     * Gets query for [[Employee0]]. <---
     *
     * @return \yii\db\ActiveQuery
     */
    public function getEmployee0() /* <--- */
    {
        return $this->hasOne(Route::class, ['employee_id' => 'employee_id', 'id' => 'route_id']);
    }
}
```

**Into this:**

```PHP
<?php

(...)

/**
 *
 * @property int $id
 * @property int $employee_id
 * @property string $route_id
 *
 * @property Employee $employee
 * @property Route $route <---
 */
class Company extends \yii\db\ActiveRecord
{
    (...)

    /**
     * Gets query for [[Employee]].
     *
     * @return \yii\db\ActiveQuery
     */
    public function getEmployee()
    {
        return $this->hasOne(Employee::class, ['id' => 'employee_id']);
    }

    /**
     * Gets query for [[Route]]. <---
     *
     * @return \yii\db\ActiveQuery
     */
    public function getRoute() /* <--- */
    {
        return $this->hasOne(Route::class, ['employee_id' => 'employee_id', 'id' => 'route_id']);
    }
}
```