### PR TITLE
Update Generator.php

### DIFF
--- a/src/generators/crud/Generator.php
+++ b/src/generators/crud/Generator.php
@@ -556,7 +556,7 @@ class Generator extends \yii\gii\Generator
     public function getTableSchema()
     {
         $class = $this->modelClass;
-        if (is_subclass_of($class, '\yii\db\BaseActiveRecord')) {
+        if (is_subclass_of($class, '\yii\db\ActiveRecord')) {
             return $class::getTableSchema();
         }
 


### PR DESCRIPTION
In yii\db\BaseActiveRecord, there is no getTableSchema method. When using Gii to generate CRUD for non-relational databases, an error occurs because the getTableSchema method cannot be found.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
