### PR TITLE
Fix #573: Fix `@property` annotations in `Generator`, `generators/model/Generator` and `generators/module/Generator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Yii Framework 2 gii extension Change Log
 - Enh #561: Applying Yii2 coding standards (@s1lver)
 - Enh #561: Raise min version to PHP 7.4 (@s1lver)
 - Bug #549: Fix decimal and money column type generation in model generator (@taobig)
-- Bug #TBD: Fix `@property` annotations in `Generator`, `generators/model/Generator` and `generators/module/Generator` (mspirkov)
+- Bug #573: Fix `@property` annotations in `Generator`, `generators/model/Generator` and `generators/module/Generator` (mspirkov)
 
 2.2.7 February 13, 2025
 -----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 gii extension Change Log
 - Enh #561: Applying Yii2 coding standards (@s1lver)
 - Enh #561: Raise min version to PHP 7.4 (@s1lver)
 - Bug #549: Fix decimal and money column type generation in model generator (@taobig)
+- Bug #TBD: Fix `@property` annotations in `Generator`, `generators/model/Generator` and `generators/module/Generator` (mspirkov)
 
 2.2.7 February 13, 2025
 -----------------------

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1519,6 +1519,12 @@ parameters:
 			path: tests/generators/ModelGeneratorMock.php
 
 		-
+			message: '#^Method yiiunit\\gii\\generators\\ModelGeneratorMock\:\:publicGenerateProperties\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/generators/ModelGeneratorMock.php
+
+		-
 			message: '#^Access to constant TYPE_CLIENT on an unknown class TestEnumModel\.$#'
 			identifier: class.notFound
 			count: 1

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -29,9 +29,8 @@ use yii\web\View;
  * - [[generate()]]: generates the code based on the current user input and the specified code template files.
  *   This is the place where main code generation code resides.
  *
- * @property-read string $name The name of the generator.
- * @property-read string $description The detailed description of the generator.
- * @property-read string $stickyDataFile The file path that stores the sticky attribute values.
+ * @property-read string $description
+ * @property-read string $stickyDataFile
  * @property-read string $templatePath The root path of the template files that are currently being used.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -25,6 +25,8 @@ use yii\helpers\StringHelper;
 /**
  * This generator will generate one or multiple ActiveRecord classes for the specified database table.
  *
+ * @property-read string $tablePrefix
+ *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */

--- a/src/generators/module/Generator.php
+++ b/src/generators/module/Generator.php
@@ -17,8 +17,10 @@ use yii\helpers\StringHelper;
  * This generator will generate the skeleton code needed by a module.
  *
  * @inheritdoc
+ *
  * @property-read string $controllerNamespace The controller namespace of the module.
  * @property-read string $modulePath The directory that contains the module class.
+ *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

See: https://github.com/yiisoft/yii2/pull/21042