### PR TITLE
Fix `ActiveField::checkbox()` and `ActiveField::radio()` label not rendered due to `generateLabel()` API change in Yii2 `22.0`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       postgres:
-        image: postgres:9.6@sha256:15055f7b681334cbf0212b58e510148b1b23973639e3904260fb41fa0761a103
+        image: postgres:14@sha256:2f439458ab6a57a925825ae14f9d06910e4fe4a41c8d4a0ae06397e65b707e1b
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,6 @@ on:
 
   push: *ignore-paths
 
-  push:
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-      - 'CHANGELOG.md'
-      - '.gitignore'
-      - '.gitattributes'
-
 permissions:
   contents: read
 
@@ -35,65 +27,65 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-    phpunit:
-        name: PHP ${{ matrix.php }} on ${{ matrix.os }}
-        runs-on: ${{ matrix.os }}
-        services:
-            postgres:
-                image: postgres:9.6@sha256:15055f7b681334cbf0212b58e510148b1b23973639e3904260fb41fa0761a103
-                env:
-                    POSTGRES_USER: postgres
-                    POSTGRES_PASSWORD: postgres
-                    POSTGRES_DB: yiitest
-                ports:
-                    - 5432:5432
-                options: --name=postgres --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-latest]
-                php: ['8.3', '8.4', '8.5']
+  phpunit:
+    name: PHP ${{ matrix.php }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    services:
+      postgres:
+        image: postgres:9.6@sha256:15055f7b681334cbf0212b58e510148b1b23973639e3904260fb41fa0761a103
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: yiitest
+        ports:
+          - 5432:5432
+        options: --name=postgres --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        php: ['8.3', '8.4', '8.5']
 
-        steps:
-            - name: Checkout
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-              with:
-                persist-credentials: false
-            - name: Install PHP
-              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
-              with:
-                  php-version: ${{ matrix.php }}
-                  tools: pecl
-                  extensions: apc, curl, dom, imagick, intl, mbstring, mcrypt, memcached, mysql, pdo, pdo_mysql, pdo_pgsql, pdo_sqlite, pgsql, sqlite
-                  ini-values: date.timezone='UTC', session.save_path="${{ runner.temp }}"
-            - name: Get composer cache directory
-              id: composer-cache
-              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-            - name: Cache composer dependencies
-              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                  restore-keys: ${{ runner.os }}-composer-
-            - name: Install dependencies
-              run: composer update $DEFAULT_COMPOSER_FLAGS
-            - name: Load database data
-              env:
-                  PGHOST: 127.0.0.1
-                  PGUSER: postgres
-                  PGDATABASE: yiitest
-                  PGPASSWORD: postgres
-                  PGPORT: ${{ job.services.postgres.ports['5432'] }}
-              run: |
-                sudo apt update && sudo apt --fix-broken install && sudo apt install -y postgresql-client
-                psql -U postgres yiitest < tests/data/pgsql.sql
-                echo "<?php unset(\$config['databases']['pgsql']['fixture']);" > tests/data/config.local.php
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: pecl
+          extensions: apc, curl, dom, imagick, intl, mbstring, mcrypt, memcached, mysql, pdo, pdo_mysql, pdo_pgsql, pdo_sqlite, pgsql, sqlite
+          ini-values: date.timezone='UTC', session.save_path="${{ runner.temp }}"
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache composer dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer update $DEFAULT_COMPOSER_FLAGS
+      - name: Load database data
+        env:
+          PGHOST: 127.0.0.1
+          PGUSER: postgres
+          PGDATABASE: yiitest
+          PGPASSWORD: postgres
+          PGPORT: ${{ job.services.postgres.ports['5432'] }}
+        run: |
+          sudo apt update && sudo apt --fix-broken install && sudo apt install -y postgresql-client
+          psql -U postgres yiitest < tests/data/pgsql.sql
+          echo "<?php unset(\$config['databases']['pgsql']['fixture']);" > tests/data/config.local.php
 
-            - name: Run unit tests with coverage
-              run: vendor/bin/phpunit --coverage-clover=coverage.clover --colors=always
+      - name: Run unit tests with coverage
+        run: vendor/bin/phpunit --coverage-clover=coverage.clover --colors=always
 
-            - name: Upload coverage to Codecov.
-              uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-              with:
-                files: ./coverage.xml
-                token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage to Codecov.
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - main
-      - '22.0'
+      - '22'
     paths:
       - '.github/**.yml'
       - '.github/**.yaml'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 gii extension Change Log
 22.0.0 under development
 ------------------------
 
-- Bug: Fix `ActiveField::checkbox()` and `ActiveField::radio()` label not rendered due to `generateLabel()` API change in Yii2 `22.0`.
+- Bug #576: Fix `ActiveField::checkbox()` and `ActiveField::radio()` label not rendered due to `generateLabel()` API change in Yii2 `22.0` (@terabytesoftw).
 
 3.0.0 under development
 -----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Yii Framework 2 gii extension Change Log
 ========================================
 
+22.0.0 under development
+------------------------
+
+- Bug: Fix `ActiveField::checkbox()` and `ActiveField::radio()` label not rendered due to `generateLabel()` API change in Yii2 `22.0`.
+
 3.0.0 under development
 -----------------------
 

--- a/src/components/ActiveField.php
+++ b/src/components/ActiveField.php
@@ -108,10 +108,13 @@ class ActiveField extends \yii\widgets\ActiveField
 
         Html::addCssClass($this->options, 'form-check');
         Html::addCssClass($options, 'form-check-input');
-        Html::addCssClass($this->labelOptions, 'form-check-label');
 
         $options['label'] ??= $this->model->getAttributeLabel($this->attribute);
-        $options['labelOptions'] ??= ['tag' => 'label'];
+        $options['labelOptions'] ??= $this->labelOptions;
+
+        Html::addCssClass($options['labelOptions'], 'form-check-label');
+
+        $options['labelOptions']['tag'] ??= 'label';
 
         return parent::checkbox($options, $enclosedByLabel);
     }
@@ -125,10 +128,11 @@ class ActiveField extends \yii\widgets\ActiveField
 
         Html::addCssClass($this->options, 'form-check');
         Html::addCssClass($options, 'form-check-input');
-        Html::addCssClass($this->labelOptions, 'form-check-label');
 
         $options['label'] ??= $this->model->getAttributeLabel($this->attribute);
-        $options['labelOptions'] ??= ['tag' => 'label'];
+        $options['labelOptions'] ??= $this->labelOptions;
+        Html::addCssClass($options['labelOptions'], 'form-check-label');
+        $options['labelOptions']['tag'] ??= 'label';
 
         return parent::radio($options, $enclosedByLabel);
     }

--- a/src/components/ActiveField.php
+++ b/src/components/ActiveField.php
@@ -105,9 +105,14 @@ class ActiveField extends \yii\widgets\ActiveField
     public function checkbox($options = [], $enclosedByLabel = false)
     {
         $this->template = "{input}\n{label}\n{error}";
+
         Html::addCssClass($this->options, 'form-check');
         Html::addCssClass($options, 'form-check-input');
         Html::addCssClass($this->labelOptions, 'form-check-label');
+
+        $options['label'] ??= $this->model->getAttributeLabel($this->attribute);
+        $options['labelOptions'] ??= ['tag' => 'label'];
+
         return parent::checkbox($options, $enclosedByLabel);
     }
 
@@ -117,9 +122,14 @@ class ActiveField extends \yii\widgets\ActiveField
     public function radio($options = [], $enclosedByLabel = false)
     {
         $this->template = "{input}\n{label}\n{error}";
+
         Html::addCssClass($this->options, 'form-check');
         Html::addCssClass($options, 'form-check-input');
         Html::addCssClass($this->labelOptions, 'form-check-label');
+
+        $options['label'] ??= $this->model->getAttributeLabel($this->attribute);
+        $options['labelOptions'] ??= ['tag' => 'label'];
+
         return parent::radio($options, $enclosedByLabel);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkbox and radio field labels not appearing correctly after the Yii2 22.0 API update.
  * Checkbox and radio fields now automatically use the model’s attribute label when no label is provided.
  * Improved default label rendering while preserving existing Bootstrap styling and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->